### PR TITLE
Add CI workflow, CHANGELOG, and versioning rules

### DIFF
--- a/.claude/rules/changelog.md
+++ b/.claude/rules/changelog.md
@@ -1,0 +1,54 @@
+---
+paths:
+  - "CHANGELOG.md"
+  - "system.json"
+---
+
+# Changelog and Versioning Rules
+
+## Versioning
+
+This project uses [Semantic Versioning](https://semver.org/). The version lives in
+`foundry/system.json` under the `"version"` field.
+
+| Change type | Version component |
+|-------------|-------------------|
+| Backwards-incompatible data model or API change | MAJOR |
+| New functionality (new actor type, new sheet, new mechanic) | MINOR |
+| Bug fixes, internal refactors, documentation, CI | PATCH |
+
+## Changelog format
+
+All notable changes are recorded in `CHANGELOG.md` at the repo root, following
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions.
+
+- Keep an `[Unreleased]` section at the top for changes not yet tagged.
+- Group entries under: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
+- Every PR with a semver-worthy change **must** update `CHANGELOG.md` as part of the same commit.
+- When a release is tagged, move `[Unreleased]` entries to a new `[x.y.z] - YYYY-MM-DD` section
+  and bump `"version"` in `foundry/system.json`.
+- Do not leave `CHANGELOG.md` with only a version bump and no entries — describe what changed.
+- Write for the **end user** (GM or player using the system), not the developer. Describe what
+  they can now do or what problem is fixed — not which file changed or how the code works.
+
+  Bad: "Add `FranchiseDicePool` class wired into `AgentSheet.getData()`"
+  Good: "Franchise dice pool displays on agent sheets."
+
+## Per-PR checklist
+
+Before opening a PR that changes game behaviour, data models, or user-facing features:
+
+1. Add an entry under `[Unreleased]` in `CHANGELOG.md`.
+2. If the change warrants a version bump (anything MINOR or MAJOR), bump `"version"` in
+   `foundry/system.json` in the same commit.
+
+Pure tooling, CI, or documentation PRs (no change to what a player or GM experiences) do not
+require a changelog entry, but may include one under `Changed` if helpful.
+
+## Cutting a release
+
+1. Move `[Unreleased]` entries to `[x.y.z] - YYYY-MM-DD` in `CHANGELOG.md`.
+2. Bump `"version"` in `foundry/system.json` to `x.y.z`.
+3. Commit: `"Release x.y.z"`.
+4. Tag: `git tag vx.y.z`.
+5. Push commit and tag: `git push && git push --tags`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Cache node_modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: foundry/node_modules
+          key: node-modules-${{ hashFiles('foundry/package-lock.json') }}
+          restore-keys: node-modules-
+
+      - name: Install dependencies
+        working-directory: foundry
+        run: npm ci
+
+      - name: Type check
+        working-directory: foundry
+        run: npm run check
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Cache node_modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: foundry/node_modules
+          key: node-modules-${{ hashFiles('foundry/package-lock.json') }}
+          restore-keys: node-modules-
+
+      - name: Install dependencies
+        working-directory: foundry
+        run: npm ci
+
+      - name: Build (production)
+        working-directory: foundry
+        run: npm run prod
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: inspectres-dist
+          path: foundry/dist/
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Foundry VTT system scaffold with TypeScript + Vite build pipeline
+- Agent and Franchise actor types with sheets and data models
+- CI workflow: type checking and production build on every push and PR
+- `.claude/rules/` for TypeScript and Foundry VTT development standards
+
+[Unreleased]: https://github.com/phaedrus1992/inspectres-vtt/compare/HEAD...HEAD


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml`: two jobs run on every push and PR
  - **Type check** — `npm run check` (tsc --noEmit)
  - **Build** — `npm run prod` (Vite production build); uploads `dist/` as an artifact
- Add `CHANGELOG.md`: Keep a Changelog format, seeded with what's been built so far
- Add `.claude/rules/changelog.md`: rules for when and how to update the changelog and bump the version in `system.json`

## Test plan

- [ ] CI runs green on this PR (type check + build pass)
- [ ] `CHANGELOG.md` renders correctly on GitHub