### PR TITLE
feat: starter compendium packs and release workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,3 +8,40 @@ Before asking the user about any game mechanics (roll procedures, augmentation r
 2. **Query MemPalace** (`mempalace_search` / `mempalace_kg_query`) for prior design decisions and session context.
 
 Only escalate to the user if the rules spec and MemPalace are both silent on a question.
+
+## Issue Tracking
+
+All issue tracking is in GitHub (`gh issue`).
+
+When code review, pre-PR analysis, or any other process surfaces a finding that gets deferred or set aside, create a GitHub issue for it rather than leaving it as a task note or ignoring it:
+
+```bash
+gh issue create --title "..." --body "..." --label "..."
+```
+
+This applies to deferred pre-pr-review findings (Step 7), security audit items not fixed in the current PR, simplification opportunities, and any other actionable work that isn't done right now.
+
+## Sprint (composite) Issues
+
+When creating a sprint/composite issue that groups constituent issues together (as in `dev-sprint`), add each constituent issue as a sub-issue of the composite using the GitHub sub-issues API:
+
+```bash
+# After creating the composite issue (number = $PARENT):
+CHILD_ID=$(gh issue view $NUMBER --json id --jq .id)
+gh api repos/:owner/:repo/issues/$PARENT/sub_issues \
+  -X POST -f sub_issue_id=$CHILD_ID
+```
+
+Repeat for each constituent issue. This lets them appear and resolve together in GitHub's UI.
+
+## Sprint (composite) Issues
+
+When creating a sprint/composite issue that groups constituent issues together (as in `dev-sprint`), add each constituent issue as a sub-issue of the composite using the GitHub sub-issues API:
+
+```bash
+# After creating the composite issue (number = $PARENT):
+gh api repos/:owner/:repo/issues/$PARENT/sub_issues \
+  -X POST -f sub_issue_id=$CHILD_ID
+```
+
+Where `$CHILD_ID` is the **issue ID** (not number — get it from `gh issue view $NUMBER --json id --jq .id`). Repeat for each constituent issue. This lets them appear and resolve together in GitHub's UI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '22'
-
-      - name: Cache node_modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: foundry/node_modules
-          key: node-modules-${{ hashFiles('foundry/package-lock.json') }}
-          restore-keys: node-modules-
+          cache: 'npm'
+          cache-dependency-path: foundry/package-lock.json
 
       - name: Install dependencies
         working-directory: foundry
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build (production)
         working-directory: foundry
@@ -39,18 +34,38 @@ jobs:
       - name: Inject release URLs into system.json
         env:
           TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
         run: |
           node -e "
             const fs = require('fs');
-            const path = 'foundry/dist/system.json';
-            const manifest = JSON.parse(fs.readFileSync(path, 'utf-8'));
-            manifest.manifest = 'https://github.com/phaedrus1992/inspectres-vtt/releases/latest/download/system.json';
-            manifest.download = \`https://github.com/phaedrus1992/inspectres-vtt/releases/download/\${process.env.TAG}/inspectres.zip\`;
-            fs.writeFileSync(path, JSON.stringify(manifest, null, 2) + '\n');
+            const tag = process.env.TAG;
+            const repo = process.env.REPO;
+            if (!tag || !/^v[0-9]+\.[0-9]+\.[0-9]+$/.test(tag)) {
+              console.error('Error: TAG is missing or does not match vX.Y.Z, got: ' + tag);
+              process.exit(1);
+            }
+            const distPath = 'foundry/dist/system.json';
+            if (!fs.existsSync(distPath)) {
+              console.error('Error: ' + distPath + ' not found — did the build step succeed?');
+              process.exit(1);
+            }
+            let manifest;
+            try {
+              manifest = JSON.parse(fs.readFileSync(distPath, 'utf-8'));
+            } catch (e) {
+              console.error('Error: failed to parse system.json: ' + e.message);
+              process.exit(1);
+            }
+            const base = 'https://github.com/' + repo + '/releases';
+            manifest.manifest = base + '/latest/download/system.json';
+            manifest.download = base + '/download/' + tag + '/inspectres.zip';
+            fs.writeFileSync(distPath, JSON.stringify(manifest, null, 2) + '\n');
+            console.log('Injected release URLs for tag: ' + tag);
           "
 
       - name: Package release zip
-        run: zip -r inspectres.zip foundry/dist/ -j
+        working-directory: foundry/dist
+        run: zip -r ../../inspectres.zip .
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@da05d552c43bd422ea6ee6f3dad0e93abd12ede6  # v2.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Cache node_modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: foundry/node_modules
+          key: node-modules-${{ hashFiles('foundry/package-lock.json') }}
+          restore-keys: node-modules-
+
+      - name: Install dependencies
+        working-directory: foundry
+        run: npm ci
+
+      - name: Build (production)
+        working-directory: foundry
+        run: npm run prod
+
+      - name: Inject release URLs into system.json
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const path = 'foundry/dist/system.json';
+            const manifest = JSON.parse(fs.readFileSync(path, 'utf-8'));
+            manifest.manifest = 'https://github.com/phaedrus1992/inspectres-vtt/releases/latest/download/system.json';
+            manifest.download = \`https://github.com/phaedrus1992/inspectres-vtt/releases/download/\${process.env.TAG}/inspectres.zip\`;
+            fs.writeFileSync(path, JSON.stringify(manifest, null, 2) + '\n');
+          "
+
+      - name: Package release zip
+        run: zip -r inspectres.zip foundry/dist/ -j
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@da05d552c43bd422ea6ee6f3dad0e93abd12ede6  # v2.2.1
+        with:
+          files: |
+            inspectres.zip
+            foundry/dist/system.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Foundry VTT system scaffold with TypeScript + Vite build pipeline
 - Agent and Franchise actor types with sheets and data models
+- Skill, stress, bank, and client rolls with full dice resolution and chat output
+- Mission Tracker app showing franchise dice pool progress, GM distribution dialog, and mission-complete flow
+- Debt mode: franchise can enter debt, blocking all rolls until resolved
+- Client rolls whispered to GM only
+- Cool pip toggle correctly deselects when clicking an already-selected pip
+- Starter compendium with blank Agent actor, blank Franchise actor, and four shortcut macros (Skill Roll, Stress Roll, Bank Roll, Client Roll)
 - CI workflow: type checking and production build on every push and PR
+- Release workflow: tags matching `v*.*.*` build and publish a GitHub release with `inspectres.zip` and `system.json`
 - `.claude/rules/` for TypeScript and Foundry VTT development standards
 
 [Unreleased]: https://github.com/phaedrus1992/inspectres-vtt/compare/HEAD...HEAD

--- a/foundry/.gitignore
+++ b/foundry/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+packs-compiled/
 *.log
 .DS_Store

--- a/foundry/package-lock.json
+++ b/foundry/package-lock.json
@@ -8,6 +8,7 @@
       "name": "inspectres-vtt",
       "version": "0.1.0",
       "devDependencies": {
+        "@foundryvtt/foundryvtt-cli": "^3.0.3",
         "@types/node": "^20.11.19",
         "@vitest/coverage-v8": "^3.1.2",
         "fvtt-types": "github:League-of-Foundry-Developers/foundry-vtt-types#main",
@@ -823,6 +824,28 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@foundryvtt/foundryvtt-cli": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@foundryvtt/foundryvtt-cli/-/foundryvtt-cli-3.0.3.tgz",
+      "integrity": "sha512-byNLOrZ9ev6PfW+gflhonT5Y+Goq2aHERwVGWO3eYRKez+lzZJoqMY/YMEi54XYozzWWn8d6LuRbBsVPJ30haw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "classic-level": "^1.4.1",
+        "esm": "^3.2.25",
+        "js-yaml": "^4.1.0",
+        "mkdirp": "^3.0.1",
+        "nedb-promises": "^6.2.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "fvtt": "fvtt.mjs"
+      },
+      "engines": {
+        "node": ">17.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1817,6 +1840,24 @@
         "win32"
       ]
     },
+    "node_modules/@seald-io/binary-search-tree": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@seald-io/binary-search-tree/-/binary-search-tree-1.0.3.tgz",
+      "integrity": "sha512-qv3jnwoakeax2razYaMsGI/luWdliBLHTdC6jU55hQt1hcFqzauH/HsBollQ7IR4ySTtYhT+xyHoijpA16C+tA==",
+      "dev": true
+    },
+    "node_modules/@seald-io/nedb": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@seald-io/nedb/-/nedb-4.1.2.tgz",
+      "integrity": "sha512-bDr6TqjBVS2rDyYM9CPxAnotj5FuNL9NF8o7h7YyFXM7yruqT4ddr+PkSb2mJvvw991bqdftazkEo38gykvaww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@seald-io/binary-search-tree": "^1.0.3",
+        "localforage": "^1.10.0",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -2088,6 +2129,25 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abstract-level": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
+      "integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2161,6 +2221,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2169,6 +2236,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -2260,6 +2343,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2291,6 +2393,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2308,6 +2420,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -2316,6 +2441,118 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/classic-level": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/codemirror": {
@@ -2485,6 +2722,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dom-serializer": {
@@ -2743,6 +2998,16 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2754,6 +3019,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -2799,6 +3074,22 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -2903,12 +3194,32 @@
         }
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-browser-rtc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
       "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -3061,12 +3372,41 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3189,6 +3529,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3232,6 +3579,60 @@
         "intl-messageformat": "1.1.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3240,6 +3641,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-object": {
@@ -3258,6 +3679,41 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3350,6 +3806,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsdom": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
@@ -3388,6 +3857,50 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/loupe": {
@@ -3515,6 +4028,32 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3541,6 +4080,23 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nedb-promises": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/nedb-promises/-/nedb-promises-6.2.3.tgz",
+      "integrity": "sha512-enq0IjNyBz9Qy9W/QPCcLGh/QORGBjXbIeZeWvIjO3OMLyAvlKT3hiJubP2BKEiFniUlR3L01o18ktqgn5jxqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@seald-io/nedb": "^4.0.2"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -3557,6 +4113,18 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
@@ -3772,6 +4340,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -4024,6 +4602,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -4104,6 +4692,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4150,6 +4756,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -4768,6 +5392,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -5038,6 +5676,28 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5206,6 +5866,90 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/foundry/package.json
+++ b/foundry/package.json
@@ -5,13 +5,17 @@
   "type": "module",
   "scripts": {
     "dev": "vite build --watch --config vite.config.ts",
-    "build": "vite build --config vite.config.ts",
-    "prod": "vite build --config vite.config.prod.ts",
+    "build": "npm run pack && vite build --config vite.config.ts",
+    "prod": "npm run pack && vite build --config vite.config.prod.ts",
+    "pack": "npm run pack:actors && npm run pack:macros",
+    "pack:actors": "fvtt package pack --id inspectres --type System -n actors --in packs/actors --out packs-compiled",
+    "pack:macros": "fvtt package pack --id inspectres --type System -n macros --in packs/macros --out packs-compiled",
     "check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@foundryvtt/foundryvtt-cli": "^3.0.3",
     "@types/node": "^20.11.19",
     "@vitest/coverage-v8": "^3.1.2",
     "fvtt-types": "github:League-of-Foundry-Developers/foundry-vtt-types#main",

--- a/foundry/packs/actors/BlankAgent.json
+++ b/foundry/packs/actors/BlankAgent.json
@@ -1,5 +1,5 @@
 {
-  "_id": "BlankAgentInSpec001",
+  "_id": "BlankAgent000001",
   "name": "Blank Agent",
   "type": "agent",
   "img": "icons/svg/mystery-man.svg",

--- a/foundry/packs/actors/BlankAgent.json
+++ b/foundry/packs/actors/BlankAgent.json
@@ -1,0 +1,29 @@
+{
+  "_id": "BlankAgentInSpec001",
+  "name": "Blank Agent",
+  "type": "agent",
+  "img": "icons/svg/mystery-man.svg",
+  "system": {
+    "description": "",
+    "skills": {
+      "academics": { "base": 2, "penalty": 0 },
+      "athletics": { "base": 2, "penalty": 0 },
+      "technology": { "base": 2, "penalty": 0 },
+      "contact": { "base": 3, "penalty": 0 }
+    },
+    "talent": "",
+    "cool": 0,
+    "isWeird": false,
+    "characteristics": [],
+    "missionPool": 0
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "inspectres",
+    "systemVersion": "0.1.0",
+    "coreVersion": "12.0.0",
+    "createdTime": null,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  }
+}

--- a/foundry/packs/actors/BlankFranchise.json
+++ b/foundry/packs/actors/BlankFranchise.json
@@ -1,5 +1,5 @@
 {
-  "_id": "BlankFranchiseInSpec1",
+  "_id": "BlankFranchise01",
   "name": "Blank Franchise",
   "type": "franchise",
   "img": "icons/svg/building.svg",

--- a/foundry/packs/actors/BlankFranchise.json
+++ b/foundry/packs/actors/BlankFranchise.json
@@ -1,0 +1,28 @@
+{
+  "_id": "BlankFranchiseInSpec1",
+  "name": "Blank Franchise",
+  "type": "franchise",
+  "img": "icons/svg/building.svg",
+  "system": {
+    "description": "",
+    "cards": {
+      "library": 4,
+      "gym": 1,
+      "credit": 1
+    },
+    "bank": 1,
+    "missionPool": 0,
+    "missionGoal": 0,
+    "debtMode": false,
+    "loanAmount": 0
+  },
+  "flags": {},
+  "_stats": {
+    "systemId": "inspectres",
+    "systemVersion": "0.1.0",
+    "coreVersion": "12.0.0",
+    "createdTime": null,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  }
+}

--- a/foundry/packs/macros/BankRoll.json
+++ b/foundry/packs/macros/BankRoll.json
@@ -1,9 +1,9 @@
 {
-  "_id": "InSpectresBankRoll01",
+  "_id": "BankRoll00000001",
   "name": "Bank Roll",
   "type": "script",
   "img": "icons/svg/coins.svg",
-  "scope": "actor",
+  "scope": "actors",
   "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'franchise') {\n  ui.notifications.warn('Select a Franchise token to roll the bank.');\n} else {\n  actor.sheet?.render(true);\n}",
   "flags": { "inspectres": { "macro": "bank-roll" } },
   "_stats": {

--- a/foundry/packs/macros/BankRoll.json
+++ b/foundry/packs/macros/BankRoll.json
@@ -1,0 +1,17 @@
+{
+  "_id": "InSpectresBankRoll01",
+  "name": "Bank Roll",
+  "type": "script",
+  "img": "icons/svg/coins.svg",
+  "scope": "actor",
+  "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'franchise') {\n  ui.notifications.warn('Select a Franchise token to roll the bank.');\n} else {\n  actor.sheet?.render(true);\n}",
+  "flags": { "inspectres": { "macro": "bank-roll" } },
+  "_stats": {
+    "systemId": "inspectres",
+    "systemVersion": "0.1.0",
+    "coreVersion": "12.0.0",
+    "createdTime": null,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  }
+}

--- a/foundry/packs/macros/ClientRoll.json
+++ b/foundry/packs/macros/ClientRoll.json
@@ -1,9 +1,9 @@
 {
-  "_id": "InSpectresClientRol1",
+  "_id": "ClientRoll000001",
   "name": "Client Roll",
   "type": "script",
   "img": "icons/svg/mystery-man-black.svg",
-  "scope": "actor",
+  "scope": "actors",
   "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'franchise') {\n  ui.notifications.warn('Select a Franchise token to generate a client.');\n} else {\n  actor.sheet?.render(true);\n}",
   "flags": { "inspectres": { "macro": "client-roll" } },
   "_stats": {

--- a/foundry/packs/macros/ClientRoll.json
+++ b/foundry/packs/macros/ClientRoll.json
@@ -1,0 +1,17 @@
+{
+  "_id": "InSpectresClientRol1",
+  "name": "Client Roll",
+  "type": "script",
+  "img": "icons/svg/mystery-man-black.svg",
+  "scope": "actor",
+  "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'franchise') {\n  ui.notifications.warn('Select a Franchise token to generate a client.');\n} else {\n  actor.sheet?.render(true);\n}",
+  "flags": { "inspectres": { "macro": "client-roll" } },
+  "_stats": {
+    "systemId": "inspectres",
+    "systemVersion": "0.1.0",
+    "coreVersion": "12.0.0",
+    "createdTime": null,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  }
+}

--- a/foundry/packs/macros/SkillRoll.json
+++ b/foundry/packs/macros/SkillRoll.json
@@ -1,0 +1,17 @@
+{
+  "_id": "InSpectresSkillRoll1",
+  "name": "Skill Roll",
+  "type": "script",
+  "img": "icons/svg/dice-target.svg",
+  "scope": "actor",
+  "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'agent') {\n  ui.notifications.warn('Select an Agent token to roll skills.');\n} else {\n  actor.sheet?.render(true);\n}",
+  "flags": { "inspectres": { "macro": "skill-roll" } },
+  "_stats": {
+    "systemId": "inspectres",
+    "systemVersion": "0.1.0",
+    "coreVersion": "12.0.0",
+    "createdTime": null,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  }
+}

--- a/foundry/packs/macros/SkillRoll.json
+++ b/foundry/packs/macros/SkillRoll.json
@@ -1,9 +1,9 @@
 {
-  "_id": "InSpectresSkillRoll1",
+  "_id": "SkillRoll0000001",
   "name": "Skill Roll",
   "type": "script",
   "img": "icons/svg/dice-target.svg",
-  "scope": "actor",
+  "scope": "actors",
   "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'agent') {\n  ui.notifications.warn('Select an Agent token to roll skills.');\n} else {\n  actor.sheet?.render(true);\n}",
   "flags": { "inspectres": { "macro": "skill-roll" } },
   "_stats": {

--- a/foundry/packs/macros/StressRoll.json
+++ b/foundry/packs/macros/StressRoll.json
@@ -1,0 +1,17 @@
+{
+  "_id": "InSpectresStressRol1",
+  "name": "Stress Roll",
+  "type": "script",
+  "img": "icons/svg/hazard.svg",
+  "scope": "actor",
+  "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'agent') {\n  ui.notifications.warn('Select an Agent token to make a Stress roll.');\n} else {\n  actor.sheet?.render(true);\n}",
+  "flags": { "inspectres": { "macro": "stress-roll" } },
+  "_stats": {
+    "systemId": "inspectres",
+    "systemVersion": "0.1.0",
+    "coreVersion": "12.0.0",
+    "createdTime": null,
+    "modifiedTime": null,
+    "lastModifiedBy": null
+  }
+}

--- a/foundry/packs/macros/StressRoll.json
+++ b/foundry/packs/macros/StressRoll.json
@@ -1,9 +1,9 @@
 {
-  "_id": "InSpectresStressRol1",
+  "_id": "StressRoll000001",
   "name": "Stress Roll",
   "type": "script",
   "img": "icons/svg/hazard.svg",
-  "scope": "actor",
+  "scope": "actors",
   "command": "const actor = token?.actor ?? character;\nif (!actor || actor.type !== 'agent') {\n  ui.notifications.warn('Select an Agent token to make a Stress roll.');\n} else {\n  actor.sheet?.render(true);\n}",
   "flags": { "inspectres": { "macro": "stress-roll" } },
   "_stats": {

--- a/foundry/system.json
+++ b/foundry/system.json
@@ -2,7 +2,7 @@
   "id": "inspectres",
   "title": "InSpectres",
   "description": "Paranormal investigation RPG system for Foundry VTT.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "compatibility": {
     "minimum": "12",
     "verified": "14"

--- a/foundry/vite.config.ts
+++ b/foundry/vite.config.ts
@@ -134,27 +134,48 @@ export default defineConfig({
           }
         }
 
-        // Copy packs (compendium content)
-        const packsDir = path.resolve(__dirname, "packs");
-        if (fs.existsSync(packsDir)) {
-          const copyDir = (dir: string, outPrefix: string): void => {
-            for (const entry of fs.readdirSync(dir)) {
+        // Copy compiled packs (LevelDB output from `npm run pack`)
+        // Source JSON in packs/ must be compiled via fvtt-cli before building.
+        const compiledPacksDir = path.resolve(__dirname, "packs-compiled");
+        if (fs.existsSync(compiledPacksDir)) {
+          function copyDir(ctx: typeof this, dir: string, outPrefix: string, depth: number = 0): void {
+            if (depth > 10) {
+              throw new Error(`Pack directory nesting too deep at ${dir}`);
+            }
+            let entries: string[];
+            try {
+              entries = fs.readdirSync(dir);
+            } catch (err: unknown) {
+              const message = err instanceof Error ? err.message : String(err);
+              throw new Error(`Failed to read packs directory ${dir}: ${message}`);
+            }
+            for (const entry of entries) {
               const entryPath = path.join(dir, entry);
-              const stat = fs.statSync(entryPath);
-              if (stat.isDirectory()) {
-                copyDir(entryPath, `${outPrefix}/${entry}`);
-              } else {
-                const content = fs.readFileSync(entryPath, "utf-8");
-                this.emitFile({ type: "asset", fileName: `${outPrefix}/${entry}`, source: content });
+              try {
+                const stat = fs.statSync(entryPath);
+                if (stat.isDirectory()) {
+                  copyDir(ctx, entryPath, `${outPrefix}/${entry}`, depth + 1);
+                } else {
+                  const content = fs.readFileSync(entryPath);
+                  ctx.emitFile({ type: "asset", fileName: `${outPrefix}/${entry}`, source: new Uint8Array(content) });
+                }
+              } catch (err: unknown) {
+                const message = err instanceof Error ? err.message : String(err);
+                throw new Error(`Failed to process pack entry ${entryPath}: ${message}`);
               }
             }
-          };
+          }
           try {
-            copyDir(packsDir, "packs");
+            copyDir(this, compiledPacksDir, "packs");
           } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
-            throw new Error(`Failed to copy packs directory: ${message}`);
+            throw new Error(`Failed to copy compiled packs: ${message}`);
           }
+        } else {
+          this.warn(
+            "packs-compiled/ not found — run `npm run pack` before building to include compendium packs. " +
+            "Skipping packs in this build."
+          );
         }
       },
     },

--- a/foundry/vite.config.ts
+++ b/foundry/vite.config.ts
@@ -133,6 +133,29 @@ export default defineConfig({
             throw new Error(`Template build failed: ${message}`);
           }
         }
+
+        // Copy packs (compendium content)
+        const packsDir = path.resolve(__dirname, "packs");
+        if (fs.existsSync(packsDir)) {
+          const copyDir = (dir: string, outPrefix: string): void => {
+            for (const entry of fs.readdirSync(dir)) {
+              const entryPath = path.join(dir, entry);
+              const stat = fs.statSync(entryPath);
+              if (stat.isDirectory()) {
+                copyDir(entryPath, `${outPrefix}/${entry}`);
+              } else {
+                const content = fs.readFileSync(entryPath, "utf-8");
+                this.emitFile({ type: "asset", fileName: `${outPrefix}/${entry}`, source: content });
+              }
+            }
+          };
+          try {
+            copyDir(packsDir, "packs");
+          } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            throw new Error(`Failed to copy packs directory: ${message}`);
+          }
+        }
       },
     },
   ],


### PR DESCRIPTION
## Summary

- Adds blank Agent and Franchise actors and four shortcut macros (Skill Roll, Stress Roll, Bank Roll, Client Roll) as bundled compendium packs in LevelDB format
- Adds `@foundryvtt/foundryvtt-cli` and a `pack` build step that compiles source JSON to LevelDB before each build
- Adds GitHub Actions release workflow triggered on `v*.*.*` tags: builds dist, injects per-tag download URL into `system.json`, zips with directory structure intact, uploads as release assets
- Bumps version to 0.2.0

## Fixes applied

- **P0** `zip -j` was flattening the dist archive to a single level; fixed with `working-directory: foundry/dist` + `zip -r ../../inspectres.zip .`
- **P0** Source JSON files shipped directly to dist — Foundry V12 requires LevelDB format; fixed by adding `fvtt package pack` as a prebuild step
- **P0** Pack `_id` fields were 17-21 chars; Foundry requires exactly 16; all corrected
- **P1** TAG validation added to URL injection script; exits 1 if missing or malformed
- **P1** `copyDir` in vite plugin now has depth limit and per-entry error handling, consistent with `walkDir`
- **P1** Macro `scope` corrected from `"actor"` to `"actors"` (valid Foundry value)
- **P2** Release workflow uses `--ignore-scripts` for `npm ci` and `github.repository` for URLs; standalone cache step replaced with setup-node built-in

## Test plan

- [ ] Type check: `npm run check` passes
- [ ] Tests: `npm test` passes (27/27)
- [ ] Production build: `npm run prod` succeeds and emits LevelDB pack directories to `dist/packs/`
- [ ] Manual: install system from a release zip and verify compendium packs are importable in Foundry V12+

Closes #32
Closes #11
Closes #12