### PR TITLE
Replace deprecated FOUNDRY_UID/GID env vars with Docker user field

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,6 +1,7 @@
 # Copy this file to .env (gitignored) and fill in your values.
 # Run `id -u` and `id -g` to get your UID and GID.
-# This makes the Foundry container run as your user so it can write to
-# bind-mounted pack files in foundry/dist/packs/.
+# Sets the container process user so it can write to bind-mounted files in foundry/dist/packs/.
 FOUNDRY_UID=
+FOUNDRY_GID=
+OUNDRY_UID=
 FOUNDRY_GID=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,11 +13,10 @@ services:
     secrets:
       - source: config_json
         target: config.json
+    user: "${FOUNDRY_UID}:${FOUNDRY_GID}"
     environment:
       FOUNDRY_HOSTNAME: foundry
       CONTAINER_PRESERVE_CONFIG: "true"
-      FOUNDRY_UID: "${FOUNDRY_UID}"
-      FOUNDRY_GID: "${FOUNDRY_GID}"
     volumes:
       - ./data:/data
       - ../foundry/dist:/data/Data/systems/inspectres:ro


### PR DESCRIPTION
## Summary

- `FOUNDRY_UID` and `FOUNDRY_GID` env vars are deprecated in felddy/foundryvtt-docker v14.360+ and now log a warning on every start
- Replace with Docker Compose native `user: "${FOUNDRY_UID}:${FOUNDRY_GID}"` service field, which achieves identical behaviour without the deprecation warning

## Test plan

- Start the container — deprecation warnings should be gone
- Verify Foundry can write `.dbtmp` lock files into `dist/packs/` (pack databases open cleanly)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)