### PR TITLE
Fix typo in .env.example: remove duplicate variable lines

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -3,5 +3,3 @@
 # Sets the container process user so it can write to bind-mounted files in foundry/dist/packs/.
 FOUNDRY_UID=
 FOUNDRY_GID=
-OUNDRY_UID=
-FOUNDRY_GID=


### PR DESCRIPTION
Removes two duplicate/malformed lines (`OUNDRY_UID=` and a second `FOUNDRY_GID=`) that were introduced in PR #46.

The file should only contain `FOUNDRY_UID=` and `FOUNDRY_GID=` once each.