### PR TITLE
Remove :ro from dist bind-mount so LevelDB packs can write lock files

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       CONTAINER_PRESERVE_CONFIG: "true"
     volumes:
       - ./data:/data
-      - ../foundry/dist:/data/Data/systems/inspectres:ro
+      - ../foundry/dist:/data/Data/systems/inspectres

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -50,6 +50,34 @@ If it is not ignored, do not proceed — do not commit credentials.
 > foundryvtt.com. Once the download is cached in `docker/data/`, they are not needed again
 > unless you reset `docker/data/`.
 
+## User ID Setup
+
+The container runs as the UID/GID you specify so it can write to bind-mounted files in
+`foundry/dist/packs/` (Foundry needs write access to open LevelDB compendium packs).
+
+Copy the example file and fill in your values:
+
+```bash
+cp docker/.env.example docker/.env
+```
+
+Then edit `docker/.env`:
+
+```bash
+# Run `id -u` and `id -g` to get your values
+FOUNDRY_UID=501
+FOUNDRY_GID=20
+```
+
+To find your values:
+
+```bash
+id -u   # UID
+id -g   # GID
+```
+
+The file is gitignored. Do not commit it.
+
 ## Starting Foundry
 
 ```bash


### PR DESCRIPTION
The `dist/` bind-mount was marked `:ro` (read-only), which prevented Foundry from writing `.dbtmp` lock files when opening LevelDB compendium packs. This caused `Read-only file system` errors on every world launch.

`foundry/dist/` is entirely gitignored build output, so there's nothing to protect with `:ro`. Removing the flag lets Foundry write the lock files it needs.