### PR TITLE
Migrate V1 Application APIs to V2 for Foundry V13 compatibility

### DIFF
--- a/.claude/rules/foundry-sheets.md
+++ b/.claude/rules/foundry-sheets.md
@@ -9,128 +9,78 @@ paths:
 
 Patterns for building Actor and Item sheets. Companion to `foundry-api.md` and `foundry-vite.md`.
 
-## Choosing Application Version
+## Application Version
 
-**ApplicationV1** (`ActorSheet`, `ItemSheet`): stable, widely documented, required for most
-system-level sheets today. Use for all current InSpectres sheets.
+All InSpectres sheets use **ApplicationV2** (`ActorSheetV2` / `ItemSheetV2`), targeting Foundry V13+.
+Do not write new sheets extending V1 `ActorSheet` / `ItemSheet` — those are deprecated in V13 and removed in V15.
 
-**ApplicationV2** (`ActorSheetV2`, `DocumentSheetV2`): newer API, cleaner TypeScript, but less
-community tooling. Consider for new sheets once fvtt-types v13 types stabilize.
-
-When in doubt, use ApplicationV1.
-
-## ActorSheet Pattern
+## ActorSheetV2 Pattern
 
 ```typescript
-export class AgentSheet extends ActorSheet {
-  static override get defaultOptions(): ActorSheet.Options {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["inspectres", "sheet", "actor", "agent"],
-      template: "systems/inspectres/templates/actors/agent-sheet.hbs",
-      width: 680,
-      height: 520,
-      tabs: [{
-        navSelector: ".sheet-tabs",
-        contentSelector: ".sheet-body",
-        initial: "stats",
-      }],
-      dragDrop: [{ dragSelector: ".item-list .item", dropSelector: null }],
+export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
+  static override DEFAULT_OPTIONS = {
+    classes: ["inspectres", "sheet", "actor", "agent"],
+    position: { width: 680, height: 520 },
+    actions: {
+      rollDice: AgentSheet.onRollDice,
+      editItem: AgentSheet.onEditItem,
+      deleteItem: AgentSheet.onDeleteItem,
+    },
+  };
+
+  static override PARTS = {
+    sheet: { template: "systems/inspectres/templates/actors/agent-sheet.hbs" },
+  };
+
+  override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
+    const base = await super._prepareContext(_options);
+    return { ...base, system: this.actor.system as AgentData };
+  }
+
+  override async _onRender(context: Record<string, unknown>, options: foundry.applications.api.ApplicationV2Options): Promise<void> {
+    await super._onRender(context, options);
+    // Attach listeners not covered by DEFAULT_OPTIONS.actions (e.g. change events)
+    this.element.querySelectorAll<HTMLInputElement>("[data-some-input]").forEach((el) => {
+      el.addEventListener("change", (event) => { /* handler */ });
     });
   }
 
-  override getData(): ActorSheet.Data & { systemData: AgentData; enrichedBio: string } {
-    const base = super.getData();
-    return {
-      ...base,
-      systemData: this.actor.system as AgentData,
-      // Pre-enrich HTML fields so templates receive safe HTML, not raw markdown
-      enrichedBio: "",  // await TextEditor.enrichHTML(this.actor.system.bio, { async: false })
-    };
-  }
-
-  override activateListeners(html: JQuery): void {
-    super.activateListeners(html);
-    if (!this.isEditable) return;
-
-    // Use event delegation on the html root, not document.body
-    html.find("[data-action='roll-dice']").on("click", this.#onRollDice.bind(this));
-    html.find("[data-action='item-create']").on("click", this.#onItemCreate.bind(this));
-    html.find("[data-action='item-delete']").on("click", this.#onItemDelete.bind(this));
-    html.find("[data-action='item-edit']").on("click", this.#onItemEdit.bind(this));
-  }
-
-  async #onRollDice(event: JQuery.ClickEvent): Promise<void> {
-    event.preventDefault();
-    const target = event.currentTarget as HTMLElement;
+  // Static action handlers — Foundry binds `this` to the sheet instance
+  static async onRollDice(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
     const rollType = target.dataset["rollType"] ?? "";
     // ... roll logic
   }
 
-  async #onItemCreate(event: JQuery.ClickEvent): Promise<void> {
-    event.preventDefault();
-    await this.actor.createEmbeddedDocuments("Item", [{
-      name: game.i18n.localize("INSPECTRES.NewItem"),
-      type: "ability",
-    }]);
-  }
-
-  async #onItemDelete(event: JQuery.ClickEvent): Promise<void> {
-    event.preventDefault();
-    const target = event.currentTarget as HTMLElement;
-    const itemId = target.closest("[data-item-id]")?.dataset["itemId"];
+  static async onEditItem(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const itemId = target.closest<HTMLElement>("[data-item-id]")?.dataset["itemId"];
     if (!itemId) return;
-    const item = this.actor.items.get(itemId);
-    await item?.delete();
+    this.actor.items.get(itemId)?.sheet?.render({ force: true });
   }
 
-  async #onItemEdit(event: JQuery.ClickEvent): Promise<void> {
-    event.preventDefault();
-    const target = event.currentTarget as HTMLElement;
-    const itemId = target.closest("[data-item-id]")?.dataset["itemId"];
+  static async onDeleteItem(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const itemId = target.closest<HTMLElement>("[data-item-id]")?.dataset["itemId"];
     if (!itemId) return;
-    this.actor.items.get(itemId)?.sheet?.render(true);
-  }
-
-  // Drag and drop support
-  override _canDragStart(_selector: string): boolean {
-    return this.isEditable;
-  }
-
-  override _onDragStart(event: DragEvent): void {
-    const target = event.currentTarget as HTMLElement;
-    const itemId = target.dataset["itemId"];
-    if (!itemId) return;
-    const item = this.actor.items.get(itemId);
-    event.dataTransfer?.setData("text/plain", JSON.stringify(item?.toDragData()));
+    await this.actor.items.get(itemId)?.delete();
   }
 }
 ```
 
-## ItemSheet Pattern
+## ItemSheetV2 Pattern
 
 ```typescript
-export class AbilitySheet extends ItemSheet {
-  static override get defaultOptions(): ItemSheet.Options {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["inspectres", "sheet", "item", "ability"],
-      template: "systems/inspectres/templates/items/ability-sheet.hbs",
-      width: 520,
-      height: 380,
-    });
-  }
+export class AbilitySheet extends foundry.applications.sheets.ItemSheetV2 {
+  static override DEFAULT_OPTIONS = {
+    classes: ["inspectres", "sheet", "item", "ability"],
+    position: { width: 520, height: 380 },
+  };
 
-  override getData(): ItemSheet.Data & { systemData: AbilityData } {
-    const base = super.getData();
-    return {
-      ...base,
-      systemData: this.item.system as AbilityData,
-    };
-  }
+  static override PARTS = {
+    sheet: { template: "systems/inspectres/templates/items/ability-sheet.hbs" },
+  };
 
-  override activateListeners(html: JQuery): void {
-    super.activateListeners(html);
-    if (!this.isEditable) return;
-    // handlers
+  override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
+    const base = await super._prepareContext(_options);
+    return { ...base, system: this.item.system as AbilityData };
   }
 }
 ```
@@ -274,49 +224,54 @@ Never hardcode color values — they break dark mode and user themes.
 
 ## Dialog Patterns
 
+Use `foundry.applications.api.DialogV2` (V2 API). `Dialog` is deprecated in V13.
+
 ```typescript
 // Simple confirmation
-const confirmed = await Dialog.confirm({
-  title: game.i18n.localize("INSPECTRES.DeleteTitle"),
+const confirmed = await foundry.applications.api.DialogV2.confirm({
+  window: { title: game.i18n.localize("INSPECTRES.DeleteTitle") },
   content: `<p>${game.i18n.localize("INSPECTRES.DeleteConfirm")}</p>`,
 });
 if (!confirmed) return;
 
-// Custom dialog with form
-const result = await new Promise<number | null>((resolve) => {
-  new Dialog({
-    title: game.i18n.localize("INSPECTRES.DicePool"),
-    content: `<form>
-      <label>${game.i18n.localize("INSPECTRES.DiceCount")}</label>
-      <input type="number" name="count" value="2" min="1" max="6">
-    </form>`,
-    buttons: {
-      roll: {
-        icon: '<i class="fas fa-dice-d6"></i>',
-        label: game.i18n.localize("INSPECTRES.Roll"),
-        callback: (html: JQuery) => {
-          resolve(Number((html.find('[name="count"]').val())));
-        },
-      },
-      cancel: {
-        label: game.i18n.localize("INSPECTRES.Cancel"),
-        callback: () => resolve(null),
+// Custom dialog with form — buttons is an array, callback receives native HTMLDialogElement
+const result = await foundry.applications.api.DialogV2.wait({
+  window: { title: game.i18n.localize("INSPECTRES.DicePool") },
+  content: `<form>
+    <label>${game.i18n.localize("INSPECTRES.DiceCount")}</label>
+    <input type="number" name="count" value="2" min="1" max="6">
+  </form>`,
+  buttons: [
+    {
+      action: "roll",
+      label: game.i18n.localize("INSPECTRES.Roll"),
+      default: true,
+      callback: (_event, _button, dialog) => {
+        const form = dialog.querySelector("form") as HTMLFormElement | null;
+        return form ? Number(new FormData(form).get("count")) : null;
       },
     },
-    default: "roll",
-  }).render(true);
+    {
+      action: "cancel",
+      label: game.i18n.localize("INSPECTRES.Cancel"),
+      callback: () => null,
+    },
+  ],
 });
+if (result === null || result === undefined) return;
 ```
 
 ## Anti-Patterns
 
 | Never do this | Do this instead |
 |---------------|-----------------|
-| Return `this.actor` from `getData()` | Spread `super.getData()`, pass `system` separately |
-| `html.find(".roll").click(...)` | Use `data-action` + event delegation |
+| Return `this.actor` from `_prepareContext()` | Spread `super._prepareContext()`, pass `system` separately |
+| `getData()` in V2 sheets | `_prepareContext()` |
+| `activateListeners(html: JQuery)` in V2 sheets | `_onRender()` + `DEFAULT_OPTIONS.actions` |
 | Hard-coded strings in templates | `{{localize "INSPECTRES.Key"}}` |
-| `document.querySelector` in sheets | `html.find(selector)` (scoped to sheet) |
+| `document.querySelector` in sheets | `this.element.querySelector(selector)` (scoped to sheet) |
 | CSS without `.inspectres` root selector | Nest under `.inspectres.sheet { ... }` |
 | Hardcoded pixel colors | `var(--color-border-light-primary)` |
-| `new Dialog(...)` without `render(true)` | Always call `.render(true)` to display |
+| `new Dialog(...)` / `Dialog.wait()` (V1, deprecated V13) | `foundry.applications.api.DialogV2.wait()` |
 | Registering sheets outside `init` hook | Always register in `Hooks.once("init", ...)` |
+| `extends ActorSheet` / `extends ItemSheet` (V1, deprecated V13) | `foundry.applications.sheets.ActorSheetV2` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- All sheets and the Mission Tracker app now use the Foundry V13 ApplicationV2 API, eliminating
+  deprecation warnings for `ActorSheet` and `Application`. Requires Foundry V13 or later.
+- Roll dialogs (skill roll, stress roll, distribute mission dice) use `DialogV2` — the new native
+  browser `<dialog>` element — instead of the deprecated V1 `Dialog`.
+- Create Actor dialog height is now fixed using the `renderDialogV2` hook (previously the hook
+  targeted V1 dialogs and had no effect in V13+).
+- Minimum supported Foundry version bumped from 12 to 13.
+
 ### Added
 
 - Foundry VTT system scaffold with TypeScript + Vite build pipeline

--- a/foundry/src/__mocks__/setup.ts
+++ b/foundry/src/__mocks__/setup.ts
@@ -13,41 +13,46 @@ class MockActor {
   }
 }
 
-// Mock ActorSheet class
-class MockActorSheet {
+// Mock ActorSheetV2 class
+class MockActorSheetV2 {
   actor: MockActor = new MockActor();
-  editable: boolean = true;
+  isEditable: boolean = true;
 
-  async getData() {
+  static DEFAULT_OPTIONS = {
+    id: "",
+    classes: [] as string[],
+    window: { title: "" },
+    position: { width: 600, height: 700 },
+    actions: {} as Record<string, unknown>,
+  };
+
+  static PARTS: Record<string, { template: string }> = {};
+
+  async _prepareContext(_options: unknown) {
     return {
       actor: this.actor,
-      data: this.actor.system,
-      editable: this.editable,
+      system: this.actor.system,
+      isEditable: this.isEditable,
     };
   }
 
-  activateListeners(html: JQuery<HTMLElement>) {
-    // stub
-  }
+  async _onRender(_context: unknown, _options: unknown) {}
+
+  render(_options?: unknown) { return Promise.resolve(this); }
+  async close(_options?: unknown) {}
 }
 
-// Mock Application class
-class MockApplication {
-  static defaultOptions = {
+// Mock ApplicationV2 class
+class MockApplicationV2 {
+  static DEFAULT_OPTIONS = {
     id: "",
     classes: [] as string[],
-    template: "",
-    title: "",
-    width: 400,
-    height: "auto",
-    resizable: true,
-    minimizable: true,
+    window: { title: "" },
+    position: { width: 400, height: "auto" as const },
   };
 
-  render(_force?: boolean) { return this; }
+  render(_options?: unknown) { return Promise.resolve(this); }
   async close(_options?: unknown) {}
-  getData(): Record<string, unknown> { return {}; }
-  activateListeners(_html: JQuery<HTMLElement>) {}
 }
 
 // Mock Hooks
@@ -118,7 +123,7 @@ const ui = {
 
 // Mock Actors collection
 const Actors = {
-  registerSheet: (system: string, sheet: typeof MockActorSheet, options: Record<string, unknown>) => {
+  registerSheet: (_system: string, _sheet: unknown, _options: Record<string, unknown>) => {
     // stub
   },
 };
@@ -142,19 +147,31 @@ class MockRoll {
   }
 }
 
-// Mock Dialog
-const Dialog = {
-  async wait<T>(config: {
-    title: string;
+// Mock DialogV2 — V2 API: buttons array, callback receives (event, button, dialogElement)
+const MockDialogV2 = {
+  async wait(config: {
     content: string;
-    buttons: Record<string, { label: string; callback: (html: JQuery) => T }>;
-    default: string;
-  }): Promise<T> {
-    const defaultKey = config.default;
-    const defaultButton = config.buttons[defaultKey];
-    if (!defaultButton) throw new Error(`Dialog: no button with key "${defaultKey}"`);
-    const mockHtml = { find: () => ({ val: () => "0", prop: () => false }) } as unknown as JQuery;
-    return defaultButton.callback(mockHtml);
+    window?: { title?: string };
+    rejectClose?: boolean;
+    modal?: boolean;
+    buttons?: Array<{
+      action: string;
+      label: string;
+      icon?: string;
+      default?: boolean;
+      callback?: (event: Event, button: HTMLButtonElement, dialog: HTMLDialogElement) => unknown;
+    }>;
+  }): Promise<unknown> {
+    const defaultButton = config.buttons?.find((b) => b.default) ?? config.buttons?.[0];
+    if (!defaultButton?.callback) return null;
+    // Provide a minimal HTMLDialogElement stub with a querySelector that finds a form
+    const mockForm = document.createElement("form");
+    const mockDialog = document.createElement("dialog") as unknown as HTMLDialogElement;
+    mockDialog.appendChild(mockForm);
+    // stub querySelector on the dialog element
+    (mockDialog as unknown as { querySelector: (sel: string) => HTMLFormElement | null }).querySelector =
+      (sel: string) => (sel === "form" ? mockForm : null);
+    return defaultButton.callback(new Event("click"), document.createElement("button"), mockDialog);
   },
 };
 
@@ -181,15 +198,12 @@ async function loadTemplates(paths: string[]): Promise<void> {
 // Assign to global
 Object.assign(globalThis, {
   Actor: MockActor,
-  ActorSheet: MockActorSheet,
-  Application: MockApplication,
   Hooks,
   CONFIG,
   game,
   ui,
   Actors,
   Roll: MockRoll,
-  Dialog,
   ChatMessage,
   renderTemplate,
   loadTemplates,
@@ -202,7 +216,30 @@ Object.assign(globalThis, {
         return Object.assign(target, source);
       },
     },
+    applications: {
+      api: {
+        ApplicationV2: MockApplicationV2,
+        DialogV2: MockDialogV2,
+      },
+      sheets: {
+        ActorSheetV2: MockActorSheetV2,
+      },
+    },
   },
 });
 
-export { MockActor, MockActorSheet, MockApplication, Hooks, CONFIG, game, ui, Actors, hookHandlers, MockRoll, Dialog, ChatMessage, renderTemplate };
+export {
+  MockActor,
+  MockActorSheetV2,
+  MockApplicationV2,
+  MockDialogV2,
+  Hooks,
+  CONFIG,
+  game,
+  ui,
+  Actors,
+  hookHandlers,
+  MockRoll,
+  ChatMessage,
+  renderTemplate,
+};

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -20,20 +20,21 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
   const stressDiceLabel = i18n?.localize("INSPECTRES.DialogStressDice") ?? "Stress Dice (1–5)";
   const coolIgnoreLabel = i18n?.format("INSPECTRES.DialogCoolIgnore", { max: String(maxCool) }) ?? `Cool dice to ignore lowest (0–${maxCool})`;
 
-  // Dialog.wait<T> is constrained by fvtt-types; cast through unknown to avoid the constraint
-  const result = await (Dialog.wait as (config: unknown) => Promise<unknown>)({
-    title: i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll",
+  const result = await foundry.applications.api.DialogV2.wait({
+    window: { title: i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll" },
     content: `
       <form class="inspectres-roll-dialog">
         <label>${stressDiceLabel}: <input type="number" name="stressDice" min="1" max="5" value="1"></label>
         ${maxCool > 0 ? `<label>${coolIgnoreLabel}: <input type="number" name="coolIgnore" min="0" max="${maxCool}" value="0"></label>` : ""}
       </form>
     `,
-    buttons: {
-      roll: {
+    buttons: [
+      {
+        action: "roll",
         label: i18n?.localize("INSPECTRES.DialogRoll") ?? "Roll",
-        callback: (html: JQuery) => {
-          const form = html.find("form")[0] as HTMLFormElement | undefined;
+        default: true,
+        callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
+          const form = dialog.querySelector("form") as HTMLFormElement | null;
           if (!form) return { stressDiceCount: 1, coolDiceUsed: 0 };
           const data = new FormData(form);
           const stressDiceCount = Math.max(1, Math.min(5, Number(data.get("stressDice") ?? 1)));
@@ -44,12 +45,12 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
           };
         },
       },
-      cancel: {
+      {
+        action: "cancel",
         label: i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel",
         callback: () => null,
       },
-    },
-    default: "roll",
+    ],
   });
 
   if (result === null || result === undefined) return;
@@ -57,160 +58,155 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
   await executeStressRoll(agent, params);
 }
 
-export class AgentSheet extends ActorSheet {
+export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
+  static override DEFAULT_OPTIONS = {
+    classes: ["inspectres", "sheet", "actor", "agent"],
+    position: { width: 600, height: 700 as number | "auto" },
+    actions: {
+      skillRoll: AgentSheet.onSkillRoll,
+      stressRoll: AgentSheet.onStressRoll,
+      skillIncrease: AgentSheet.onSkillStep,
+      skillDecrease: AgentSheet.onSkillStep,
+      addCharacteristic: AgentSheet.onAddCharacteristic,
+      removeCharacteristic: AgentSheet.onRemoveCharacteristic,
+    },
+  };
 
-  static override get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["inspectres", "sheet", "actor", "agent"],
-      template: "systems/inspectres/templates/agent-sheet.hbs",
-      width: 600,
-      height: 700,
-    });
-  }
+  static override PARTS = {
+    sheet: { template: "systems/inspectres/templates/agent-sheet.hbs" },
+  };
 
-  override async getData() {
-    const context = await super.getData();
+  override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
+    const base = await super._prepareContext(_options);
     const system = this.actor.system as unknown as AgentData;
-    return {
-      ...context,
-      system,
-    };
+    return { ...base, system };
   }
 
-  override activateListeners(html: JQuery<HTMLElement>) {
-    super.activateListeners(html);
+  override async _onRender(context: Record<string, unknown>, options: foundry.applications.api.ApplicationV2Options): Promise<void> {
+    await super._onRender(context, options);
 
-    // Skill roll
-    html.on("click", "[data-action='skillRoll']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const skillAttr = (event.currentTarget as HTMLElement).getAttribute("data-skill");
-      if (!isSkillName(skillAttr)) {
-        console.error("skillRoll: missing or invalid data-skill attribute", skillAttr);
-        return;
-      }
-      const franchise = findFranchiseActor();
-      if (franchise && franchiseSystemData(franchise).debtMode) {
-        ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnSkillRollDebtMode") ?? "Skill rolls are blocked while in Debt Mode.");
-        return;
-      }
-      void executeSkillRoll(this.actor, franchise, skillAttr).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Skill roll failed:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
+    // Cool pip toggle (not covered by DEFAULT_OPTIONS.actions — uses change event)
+    this.element.querySelectorAll<HTMLInputElement>(".weird-checkbox").forEach((el) => {
+      el.addEventListener("change", (event: Event) => {
+        const updateData = { "system.isWeird": (event.target as HTMLInputElement).checked } as unknown as Parameters<typeof this.actor.update>[0];
+        void this.actor.update(updateData).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error("Failed to toggle weird status:", message);
+          ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
+        });
       });
     });
 
-    // Stress roll
-    html.on("click", "[data-action='stressRoll']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const franchise = findFranchiseActor();
-      if (franchise && franchiseSystemData(franchise).debtMode) {
-        ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnStressRollDebtMode") ?? "Stress rolls are blocked while in Debt Mode.");
-        return;
-      }
-      void buildStressRollDialog(this.actor).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Stress roll failed:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
+    this.element.querySelectorAll<HTMLElement>(".cool-pip").forEach((el) => {
+      el.addEventListener("click", (event: Event) => {
+        event.preventDefault();
+        const valueStr = (event.currentTarget as HTMLElement).getAttribute("data-value");
+        if (valueStr == null) {
+          console.error("cool-pip: missing data-value attribute");
+          return;
+        }
+        const pipValue = Number(valueStr);
+        if (Number.isNaN(pipValue) || pipValue < 1 || pipValue > 3) {
+          console.error("cool-pip: invalid data-value", valueStr);
+          return;
+        }
+        const currentCool = (this.actor.system as unknown as AgentData).cool;
+        const newCool = currentCool >= pipValue ? pipValue - 1 : pipValue;
+        const updateData = { "system.cool": newCool } as unknown as Parameters<typeof this.actor.update>[0];
+        void this.actor.update(updateData).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error("Failed to set cool dice:", message);
+          ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
+        });
       });
     });
+  }
 
-    // Skill base increment/decrement
-    html.on("click", "[data-action='skillIncrease'],[data-action='skillDecrease']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const el = event.currentTarget as HTMLElement;
-      const skillAttr = el.getAttribute("data-skill");
-      if (!isSkillName(skillAttr)) {
-        console.error("skill step: missing or invalid data-skill", skillAttr);
-        return;
-      }
-      const system = this.actor.system as unknown as AgentData;
-      const skillData = system.skills[skillAttr];
-      if (!skillData) {
-        console.error(`skill step: skills.${skillAttr} missing on actor ${this.actor.id}`);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
-        return;
-      }
-      const current = skillData.base;
-      const delta = el.getAttribute("data-action") === "skillIncrease" ? 1 : -1;
-      const next = Math.min(4, Math.max(0, current + delta));
-      if (next === current) return;
-      const updateData = { [`system.skills.${skillAttr}.base`]: next } as unknown as Parameters<typeof this.actor.update>[0];
-      void this.actor.update(updateData).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Failed to update skill:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
-      });
+  static async onSkillRoll(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const skillAttr = target.getAttribute("data-skill");
+    if (!isSkillName(skillAttr)) {
+      console.error("skillRoll: missing or invalid data-skill attribute", skillAttr);
+      return;
+    }
+    const franchise = findFranchiseActor();
+    if (franchise && franchiseSystemData(franchise).debtMode) {
+      ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnSkillRollDebtMode") ?? "Skill rolls are blocked while in Debt Mode.");
+      return;
+    }
+    void executeSkillRoll(this.actor, franchise, skillAttr).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Skill roll failed:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
     });
+  }
 
-    // Cool toggle
-    html.on("change", ".weird-checkbox", (event: JQuery.ChangeEvent) => {
-      event.preventDefault();
-      const updateData = { "system.isWeird": (event.target as HTMLInputElement).checked } as unknown as Parameters<typeof this.actor.update>[0];
-      void this.actor.update(updateData).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Failed to toggle weird status:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
-      });
+  static async onStressRoll(this: AgentSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    const franchise = findFranchiseActor();
+    if (franchise && franchiseSystemData(franchise).debtMode) {
+      ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnStressRollDebtMode") ?? "Stress rolls are blocked while in Debt Mode.");
+      return;
+    }
+    void buildStressRollDialog(this.actor).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Stress roll failed:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
     });
+  }
 
-    // Cool pip toggle (normal agents): clicking active pip toggles it off (cool = pipValue - 1)
-    html.on("click", ".cool-pip", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const valueStr = (event.currentTarget as HTMLElement).getAttribute("data-value");
-      if (valueStr == null) {
-        console.error("cool-pip: missing data-value attribute");
-        return;
-      }
-      const pipValue = Number(valueStr);
-      if (Number.isNaN(pipValue) || pipValue < 1 || pipValue > 3) {
-        console.error("cool-pip: invalid data-value", valueStr);
-        return;
-      }
-      const currentCool = (this.actor.system as unknown as AgentData).cool;
-      const newCool = currentCool >= pipValue ? pipValue - 1 : pipValue;
-      const updateData = { "system.cool": newCool } as unknown as Parameters<typeof this.actor.update>[0];
-      void this.actor.update(updateData).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Failed to set cool dice:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
-      });
+  static async onSkillStep(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const skillAttr = target.getAttribute("data-skill");
+    if (!isSkillName(skillAttr)) {
+      console.error("skill step: missing or invalid data-skill", skillAttr);
+      return;
+    }
+    const system = this.actor.system as unknown as AgentData;
+    const skillData = system.skills[skillAttr];
+    if (!skillData) {
+      console.error(`skill step: skills.${skillAttr} missing on actor ${this.actor.id}`);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
+      return;
+    }
+    const current = skillData.base;
+    const delta = target.getAttribute("data-action") === "skillIncrease" ? 1 : -1;
+    const next = Math.min(4, Math.max(0, current + delta));
+    if (next === current) return;
+    const updateData = { [`system.skills.${skillAttr}.base`]: next } as unknown as Parameters<typeof this.actor.update>[0];
+    void this.actor.update(updateData).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Failed to update skill:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
     });
+  }
 
-    // Add characteristic
-    html.on("click", "[data-action='addCharacteristic']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const currentSystem = this.actor.system as unknown as AgentData;
-      const characteristics = (currentSystem.characteristics || []) as AgentCharacteristic[];
-      const updateData = { "system.characteristics": [...characteristics, { text: "", used: false }] } as unknown as Parameters<typeof this.actor.update>[0];
-      void this.actor.update(updateData).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Failed to add characteristic:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorAddCharacteristic") ?? "Failed to add characteristic");
-      });
+  static async onAddCharacteristic(this: AgentSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    const currentSystem = this.actor.system as unknown as AgentData;
+    const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
+    const updateData = { "system.characteristics": [...characteristics, { text: "", used: false }] } as unknown as Parameters<typeof this.actor.update>[0];
+    void this.actor.update(updateData).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Failed to add characteristic:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorAddCharacteristic") ?? "Failed to add characteristic");
     });
+  }
 
-    // Remove characteristic
-    html.on("click", "[data-action='removeCharacteristic']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const idxStr = (event.currentTarget as HTMLElement).getAttribute("data-idx");
-      if (idxStr == null) {
-        console.error("removeCharacteristic: missing data-idx attribute");
-        return;
-      }
-      const idx = Number(idxStr);
-      if (Number.isNaN(idx) || idx < 0) {
-        console.error("removeCharacteristic: invalid data-idx value", idxStr);
-        return;
-      }
-      const currentSystem = this.actor.system as unknown as AgentData;
-      const characteristics = (currentSystem.characteristics || []) as AgentCharacteristic[];
-      const updateData = { "system.characteristics": characteristics.filter((_: AgentCharacteristic, i: number) => i !== idx) } as unknown as Parameters<typeof this.actor.update>[0];
-      void this.actor.update(updateData).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Failed to remove characteristic:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRemoveCharacteristic") ?? "Failed to remove characteristic");
-      });
+  static async onRemoveCharacteristic(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const idxStr = target.getAttribute("data-idx");
+    if (idxStr == null) {
+      console.error("removeCharacteristic: missing data-idx attribute");
+      return;
+    }
+    const idx = Number(idxStr);
+    if (Number.isNaN(idx) || idx < 0) {
+      console.error("removeCharacteristic: invalid data-idx value", idxStr);
+      return;
+    }
+    const currentSystem = this.actor.system as unknown as AgentData;
+    const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
+    const updateData = { "system.characteristics": characteristics.filter((_: AgentCharacteristic, i: number) => i !== idx) } as unknown as Parameters<typeof this.actor.update>[0];
+    void this.actor.update(updateData).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Failed to remove characteristic:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRemoveCharacteristic") ?? "Failed to remove characteristic");
     });
   }
 }

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -72,6 +72,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       stressRoll: AgentSheet.onStressRoll,
       skillIncrease: AgentSheet.onSkillStep,
       skillDecrease: AgentSheet.onSkillStep,
+      toggleCool: AgentSheet.onToggleCool,
       addCharacteristic: AgentSheet.onAddCharacteristic,
       removeCharacteristic: AgentSheet.onRemoveCharacteristic,
     },
@@ -102,29 +103,6 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       });
     }
 
-    for (const el of this.element.querySelectorAll<HTMLElement>(".cool-pip")) {
-      el.addEventListener("click", (event: Event) => {
-        event.preventDefault();
-        const valueStr = (event.currentTarget as HTMLElement).getAttribute("data-value");
-        if (valueStr == null) {
-          console.error("cool-pip: missing data-value attribute");
-          return;
-        }
-        const pipValue = Number(valueStr);
-        if (Number.isNaN(pipValue) || pipValue < 1 || pipValue > 3) {
-          console.error("cool-pip: invalid data-value", valueStr);
-          return;
-        }
-        const currentCool = (this.actor.system as unknown as AgentData).cool;
-        const newCool = currentCool >= pipValue ? pipValue - 1 : pipValue;
-        const updateData = { "system.cool": newCool } as unknown as Parameters<typeof this.actor.update>[0];
-        void this.actor.update(updateData).catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          console.error("Failed to set cool dice:", message);
-          ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
-        });
-      });
-    }
   }
 
   static async onSkillRoll(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
@@ -179,6 +157,27 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
     void this.actor.update(updateData).catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       console.error("Failed to update skill:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
+    });
+  }
+
+  static async onToggleCool(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    const valueStr = target.getAttribute("data-value");
+    if (valueStr == null) {
+      console.error("toggleCool: missing data-value attribute");
+      return;
+    }
+    const pipValue = Number(valueStr);
+    if (Number.isNaN(pipValue) || pipValue < 1 || pipValue > 3) {
+      console.error("toggleCool: invalid data-value", valueStr);
+      return;
+    }
+    const currentCool = (this.actor.system as unknown as AgentData).cool;
+    const newCool = currentCool >= pipValue ? pipValue - 1 : pipValue;
+    const updateData = { "system.cool": newCool } as unknown as Parameters<typeof this.actor.update>[0];
+    void this.actor.update(updateData).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Failed to set cool dice:", message);
       ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
     });
   }

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -85,8 +85,8 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
   override async _onRender(context: Record<string, unknown>, options: foundry.applications.api.ApplicationV2Options): Promise<void> {
     await super._onRender(context, options);
 
-    // Cool pip toggle (not covered by DEFAULT_OPTIONS.actions — uses change event)
-    this.element.querySelectorAll<HTMLInputElement>(".weird-checkbox").forEach((el) => {
+    // weird-checkbox: change event not covered by DEFAULT_OPTIONS.actions
+    for (const el of this.element.querySelectorAll<HTMLInputElement>(".weird-checkbox")) {
       el.addEventListener("change", (event: Event) => {
         const updateData = { "system.isWeird": (event.target as HTMLInputElement).checked } as unknown as Parameters<typeof this.actor.update>[0];
         void this.actor.update(updateData).catch((err: unknown) => {
@@ -95,9 +95,9 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
           ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
         });
       });
-    });
+    }
 
-    this.element.querySelectorAll<HTMLElement>(".cool-pip").forEach((el) => {
+    for (const el of this.element.querySelectorAll<HTMLElement>(".cool-pip")) {
       el.addEventListener("click", (event: Event) => {
         event.preventDefault();
         const valueStr = (event.currentTarget as HTMLElement).getAttribute("data-value");
@@ -119,7 +119,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
           ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
         });
       });
-    });
+    }
   }
 
   static async onSkillRoll(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -22,6 +22,7 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
 
   const result = await foundry.applications.api.DialogV2.wait({
     window: { title: i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll" },
+    rejectClose: false,
     content: `
       <form class="inspectres-roll-dialog">
         <label>${stressDiceLabel}: <input type="number" name="stressDice" min="1" max="5" value="1"></label>

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -36,7 +36,10 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
         default: true,
         callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
           const form = dialog.querySelector("form") as HTMLFormElement | null;
-          if (!form) return { stressDiceCount: 1, coolDiceUsed: 0 };
+          if (!form) {
+            console.error("buildStressRollDialog: form element not found in dialog; using defaults");
+            return { stressDiceCount: 1, coolDiceUsed: 0 };
+          }
           const data = new FormData(form);
           const stressDiceCount = Math.max(1, Math.min(5, Number(data.get("stressDice") ?? 1)));
           const coolDiceUsed = Math.max(0, Math.min(maxCool, Number(data.get("coolIgnore") ?? 0)));

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -66,6 +66,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
   static override DEFAULT_OPTIONS = {
     classes: ["inspectres", "sheet", "actor", "agent"],
     position: { width: 600, height: 700 as number | "auto" },
+    form: { submitOnChange: true, closeOnSubmit: false },
     actions: {
       skillRoll: AgentSheet.onSkillRoll,
       stressRoll: AgentSheet.onStressRoll,

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -2,63 +2,56 @@ import { type FranchiseData } from "./franchise-schema.js";
 import { executeBankRoll, executeClientRoll } from "../rolls/roll-executor.js";
 import { MissionTrackerApp } from "../mission/MissionTrackerApp.js";
 
-export class FranchiseSheet extends ActorSheet {
-  static override get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["inspectres", "sheet", "actor", "franchise"],
-      template: "systems/inspectres/templates/franchise-sheet.hbs",
-      width: 600,
-      height: 600,
-    });
-  }
+export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
+  static override DEFAULT_OPTIONS = {
+    classes: ["inspectres", "sheet", "actor", "franchise"],
+    position: { width: 600, height: 600 as number | "auto" },
+    actions: {
+      bankRoll: FranchiseSheet.onBankRoll,
+      clientRoll: FranchiseSheet.onClientRoll,
+      openMissionTracker: FranchiseSheet.onOpenMissionTracker,
+    },
+  };
 
-  override async getData() {
-    const context = await super.getData();
+  static override PARTS = {
+    sheet: { template: "systems/inspectres/templates/franchise-sheet.hbs" },
+  };
+
+  override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
+    const base = await super._prepareContext(_options);
     const system = this.actor.system as unknown as FranchiseData;
     const isGm = game.user?.isGM ?? false;
     const missionComplete = system.missionGoal > 0 && system.missionPool >= system.missionGoal;
-    return {
-      ...context,
-      system,
-      isGm,
-      missionComplete,
-    };
+    return { ...base, system, isGm, missionComplete };
   }
 
-  override activateListeners(html: JQuery<HTMLElement>) {
-    super.activateListeners(html);
-
-    html.on("click", "[data-action='bankRoll']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const system = this.actor.system as unknown as FranchiseData;
-      if (system.debtMode) {
-        ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnBankRollDebtMode") ?? "Bank rolls are disabled in Debt Mode.");
-        return;
-      }
-      void executeBankRoll(this.actor).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Bank roll failed:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
-      });
+  static async onBankRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    const system = this.actor.system as unknown as FranchiseData;
+    if (system.debtMode) {
+      ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnBankRollDebtMode") ?? "Bank rolls are disabled in Debt Mode.");
+      return;
+    }
+    void executeBankRoll(this.actor).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Bank roll failed:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
     });
+  }
 
-    html.on("click", "[data-action='clientRoll']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      const clientSystem = this.actor.system as unknown as FranchiseData;
-      if (clientSystem.debtMode) {
-        ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnClientRollDebtMode") ?? "Client rolls are disabled in Debt Mode.");
-        return;
-      }
-      void executeClientRoll(this.actor).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Client roll failed:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
-      });
+  static async onClientRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    const system = this.actor.system as unknown as FranchiseData;
+    if (system.debtMode) {
+      ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnClientRollDebtMode") ?? "Client rolls are disabled in Debt Mode.");
+      return;
+    }
+    void executeClientRoll(this.actor).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Client roll failed:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Roll failed");
     });
+  }
 
-    html.on("click", "[data-action='openMissionTracker']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      MissionTrackerApp.open();
-    });
+  static onOpenMissionTracker(_event: Event, _target: HTMLElement): void {
+    MissionTrackerApp.open();
   }
 }

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -6,6 +6,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
   static override DEFAULT_OPTIONS = {
     classes: ["inspectres", "sheet", "actor", "franchise"],
     position: { width: 600, height: 600 as number | "auto" },
+    form: { submitOnChange: true, closeOnSubmit: false },
     actions: {
       bankRoll: FranchiseSheet.onBankRoll,
       clientRoll: FranchiseSheet.onClientRoll,

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -34,14 +34,14 @@ Hooks.once("init", async function () {
   // Register Handlebars helpers
   registerHandlebarsHelpers();
 
-  // Register sheets
-  Actors.registerSheet("inspectres", AgentSheet, {
+  // Register sheets — cast needed because fvtt-types' registerSheet expects V1 constructor type
+  Actors.registerSheet("inspectres", AgentSheet as never, {
     types: ["agent" as never],
     makeDefault: true,
     label: "INSPECTRES.SheetAgent",
   });
 
-  Actors.registerSheet("inspectres", FranchiseSheet, {
+  Actors.registerSheet("inspectres", FranchiseSheet as never, {
     types: ["franchise" as never],
     makeDefault: true,
     label: "INSPECTRES.SheetFranchise",
@@ -49,7 +49,7 @@ Hooks.once("init", async function () {
 });
 
 // The Create Actor dialog defaults to a fixed height too small to show all fields.
-// renderDialogV2 fires for ApplicationV2-based dialogs (Foundry V12+).
+// renderDialogV2 fires for ApplicationV2-based dialogs (Foundry V13+).
 // Match on the select[name="type"] presence — unique to document-creation dialogs.
 Hooks.on("renderDialogV2", function (_app, html: HTMLElement) {
   if (html.querySelector("select[name='type']")) {
@@ -60,8 +60,7 @@ Hooks.on("renderDialogV2", function (_app, html: HTMLElement) {
 Hooks.once("ready", function () {
   onMissionSocketEvent(() => {
     if (MissionTrackerApp.instance) {
-      // fvtt-types types render() as Application, but runtime returns Promise<Application>
-      void (MissionTrackerApp.instance.render(false) as unknown as Promise<unknown>).catch((err: unknown) => {
+      void MissionTrackerApp.instance.render().catch((err: unknown) => {
         console.error("Mission tracker re-render failed (socket event):", err);
       });
     }
@@ -70,10 +69,8 @@ Hooks.once("ready", function () {
 
 Hooks.on("updateActor", function (actor: Actor) {
   if ((actor.type as string) === "franchise" && MissionTrackerApp.instance) {
-    // fvtt-types types render() as Application, but runtime returns Promise<Application>
-    void (MissionTrackerApp.instance.render(false) as unknown as Promise<unknown>).catch((err: unknown) => {
+    void MissionTrackerApp.instance.render().catch((err: unknown) => {
       console.error("Mission tracker re-render failed (actor update):", err);
     });
   }
 });
-

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -1,5 +1,4 @@
 import { findFranchiseActor, franchiseSystemData } from "../franchise/franchise-utils.js";
-import { type FranchiseData } from "../franchise/franchise-schema.js";
 
 export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
   static instance: MissionTrackerApp | null = null;
@@ -8,7 +7,11 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
     if (!MissionTrackerApp.instance) {
       MissionTrackerApp.instance = new MissionTrackerApp();
     }
-    void MissionTrackerApp.instance.render({ force: true });
+    void MissionTrackerApp.instance.render({ force: true }).catch((err: unknown) => {
+      console.error("Failed to open Mission Tracker:", err);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorMissionTrackerOpen") ?? "Failed to open Mission Tracker");
+      MissionTrackerApp.instance = null;
+    });
   }
 
   static override DEFAULT_OPTIONS: foundry.applications.api.ApplicationV2Options = {
@@ -121,12 +124,11 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
       return;
     }
 
-    await this.broadcastMissionComplete(franchise, system, distribution);
+    await this.broadcastMissionComplete(franchise, distribution);
   }
 
   private async broadcastMissionComplete(
     franchise: Actor,
-    system: FranchiseData,
     distribution: Record<string, number>,
   ): Promise<void> {
     const updateData = { "system.missionPool": 0 } as unknown as Parameters<typeof franchise.update>[0];
@@ -144,8 +146,11 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
     const content = `<p>${baseMsg}</p><ul>${lines.map((l) => `<li>${l}</li>`).join("")}</ul>`;
     await ChatMessage.create({ content } as unknown as Parameters<typeof ChatMessage.create>[0]);
 
-    void system;
-    if (MissionTrackerApp.instance === this) void this.render();
+    if (MissionTrackerApp.instance === this) {
+      void this.render().catch((err: unknown) => {
+        console.error("Mission tracker re-render failed (broadcastMissionComplete):", err);
+      });
+    }
   }
 
   private async endEarly(): Promise<void> {
@@ -160,7 +165,11 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
     const msg = game.i18n?.localize("INSPECTRES.MissionEndedEarly") ?? "The mission ended early. Franchise pool cleared.";
     await ChatMessage.create({ content: `<p>${msg}</p>` } as unknown as Parameters<typeof ChatMessage.create>[0]);
 
-    if (MissionTrackerApp.instance === this) void this.render();
+    if (MissionTrackerApp.instance === this) {
+      void this.render().catch((err: unknown) => {
+        console.error("Mission tracker re-render failed (endEarly):", err);
+      });
+    }
   }
 
   override async close(options?: { animate?: boolean }): Promise<foundry.applications.api.ApplicationV2> {

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -87,6 +87,7 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
 
     const result = await foundry.applications.api.DialogV2.wait({
       window: { title: game.i18n?.localize("INSPECTRES.DistributeDialogTitle") ?? "Distribute Mission Dice" },
+      rejectClose: false,
       content,
       buttons: [
         {

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -1,30 +1,35 @@
 import { findFranchiseActor, franchiseSystemData } from "../franchise/franchise-utils.js";
 import { type FranchiseData } from "../franchise/franchise-schema.js";
 
-export class MissionTrackerApp extends Application {
+export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
   static instance: MissionTrackerApp | null = null;
 
   static open(): void {
     if (!MissionTrackerApp.instance) {
       MissionTrackerApp.instance = new MissionTrackerApp();
     }
-    MissionTrackerApp.instance.render(true);
+    void MissionTrackerApp.instance.render({ force: true });
   }
 
-  static override get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      id: "inspectres-mission-tracker",
-      classes: ["inspectres", "inspectres-mission-tracker-window"],
-      template: "systems/inspectres/templates/mission-tracker.hbs",
-      title: game.i18n?.localize("INSPECTRES.MissionTrackerTitle") ?? "Mission Tracker",
-      width: 360,
-      height: "auto",
+  static override DEFAULT_OPTIONS: foundry.applications.api.ApplicationV2Options = {
+    id: "inspectres-mission-tracker",
+    classes: ["inspectres", "inspectres-mission-tracker-window"],
+    window: {
+      title: "INSPECTRES.MissionTrackerTitle",
       resizable: false,
-      minimizable: true,
-    });
-  }
+    },
+    position: { width: 360, height: "auto" },
+    actions: {
+      beginCleanUp: MissionTrackerApp.onBeginCleanUp,
+      endEarly: MissionTrackerApp.onEndEarly,
+    },
+  };
 
-  override getData(): Record<string, unknown> {
+  static override PARTS = {
+    sheet: { template: "systems/inspectres/templates/mission-tracker.hbs" },
+  };
+
+  override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
     const franchise = findFranchiseActor();
     if (!franchise) {
       return { missionPool: 0, missionGoal: 0, progressPercent: 0, missionComplete: false, isGm: game.user?.isGM ?? false };
@@ -34,34 +39,22 @@ export class MissionTrackerApp extends Application {
     const missionGoal = system.missionGoal;
     const progressPercent = missionGoal > 0 ? Math.min(100, Math.round((missionPool / missionGoal) * 100)) : 0;
     const missionComplete = missionGoal > 0 && missionPool >= missionGoal;
-    return {
-      missionPool,
-      missionGoal,
-      progressPercent,
-      missionComplete,
-      isGm: game.user?.isGM ?? false,
-    };
+    return { missionPool, missionGoal, progressPercent, missionComplete, isGm: game.user?.isGM ?? false };
   }
 
-  override activateListeners(html: JQuery<HTMLElement>) {
-    super.activateListeners(html);
-
-    html.on("click", "[data-action='beginCleanUp']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      void this.openDistributionDialog().catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("Distribution dialog failed:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Operation failed");
-      });
+  static async onBeginCleanUp(this: MissionTrackerApp, _event: Event, _target: HTMLElement): Promise<void> {
+    void this.openDistributionDialog().catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("Distribution dialog failed:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorRollFailed") ?? "Operation failed");
     });
+  }
 
-    html.on("click", "[data-action='endEarly']", (event: JQuery.ClickEvent) => {
-      event.preventDefault();
-      void this.endEarly().catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error("End mission early failed:", message);
-        ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
-      });
+  static async onEndEarly(this: MissionTrackerApp, _event: Event, _target: HTMLElement): Promise<void> {
+    void this.endEarly().catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("End mission early failed:", message);
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorUpdateFailed") ?? "Failed to update actor data");
     });
   }
 
@@ -89,14 +82,16 @@ export class MissionTrackerApp extends Application {
       </form>
     `;
 
-    const result = await (Dialog.wait as (config: unknown) => Promise<unknown>)({
-      title: game.i18n?.localize("INSPECTRES.DistributeDialogTitle") ?? "Distribute Mission Dice",
+    const result = await foundry.applications.api.DialogV2.wait({
+      window: { title: game.i18n?.localize("INSPECTRES.DistributeDialogTitle") ?? "Distribute Mission Dice" },
       content,
-      buttons: {
-        confirm: {
+      buttons: [
+        {
+          action: "confirm",
           label: game.i18n?.localize("INSPECTRES.DistributeDialogConfirm") ?? "Confirm",
-          callback: (html: JQuery) => {
-            const form = html.find("form")[0] as HTMLFormElement | undefined;
+          default: true,
+          callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
+            const form = dialog.querySelector("form") as HTMLFormElement | null;
             if (!form) return null;
             const data = new FormData(form);
             const distribution: Record<string, number> = {};
@@ -107,12 +102,12 @@ export class MissionTrackerApp extends Application {
             return distribution;
           },
         },
-        cancel: {
+        {
+          action: "cancel",
           label: game.i18n?.localize("INSPECTRES.DistributeDialogCancel") ?? "Cancel",
           callback: () => null,
         },
-      },
-      default: "confirm",
+      ],
     });
 
     if (result === null || result === undefined) return;
@@ -150,7 +145,7 @@ export class MissionTrackerApp extends Application {
     await ChatMessage.create({ content } as unknown as Parameters<typeof ChatMessage.create>[0]);
 
     void system;
-    if (MissionTrackerApp.instance === this) this.render(false);
+    if (MissionTrackerApp.instance === this) void this.render();
   }
 
   private async endEarly(): Promise<void> {
@@ -165,10 +160,10 @@ export class MissionTrackerApp extends Application {
     const msg = game.i18n?.localize("INSPECTRES.MissionEndedEarly") ?? "The mission ended early. Franchise pool cleared.";
     await ChatMessage.create({ content: `<p>${msg}</p>` } as unknown as Parameters<typeof ChatMessage.create>[0]);
 
-    if (MissionTrackerApp.instance === this) this.render(false);
+    if (MissionTrackerApp.instance === this) void this.render();
   }
 
-  override close(options?: Application.CloseOptions): Promise<void> {
+  override async close(options?: { animate?: boolean }): Promise<foundry.applications.api.ApplicationV2> {
     MissionTrackerApp.instance = null;
     return super.close(options);
   }

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -255,15 +255,16 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
     </form>
   `;
 
-  // Dialog.wait<T> is constrained by fvtt-types; cast through unknown to avoid the constraint
-  const result = await (Dialog.wait as (config: unknown) => Promise<unknown>)({
-    title: `${i18n?.localize("INSPECTRES.SkillRoll") ?? "Skill Roll"}: ${opts.skillName}`,
+  const result = await foundry.applications.api.DialogV2.wait({
+    window: { title: `${i18n?.localize("INSPECTRES.SkillRoll") ?? "Skill Roll"}: ${opts.skillName}` },
     content,
-    buttons: {
-      roll: {
+    buttons: [
+      {
+        action: "roll",
         label: i18n?.localize("INSPECTRES.DialogRoll") ?? "Roll",
-        callback: (html: JQuery) => {
-          const form = html.find("form")[0] as HTMLFormElement | undefined;
+        default: true,
+        callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
+          const form = dialog.querySelector("form") as HTMLFormElement | null;
           if (!form) return { cardDice: 0, bankDice: 0, coolDice: 0, talentDie: false, takesFour: false };
           const data = new FormData(form);
           const cardDice = data.has("cardDice") ? opts.availableCardDice : 0;
@@ -274,12 +275,12 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
           return { cardDice, bankDice: isNaN(bankDice) ? 0 : bankDice, coolDice: isNaN(coolDice) ? 0 : coolDice, talentDie, takesFour };
         },
       },
-      cancel: {
+      {
+        action: "cancel",
         label: i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel",
         callback: () => null,
       },
-    },
-    default: "roll",
+    ],
   });
   if (result === null || result === undefined) return null;
   return result as SkillRollAugmentation;

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -266,7 +266,10 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
         default: true,
         callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
           const form = dialog.querySelector("form") as HTMLFormElement | null;
-          if (!form) return { cardDice: 0, bankDice: 0, coolDice: 0, talentDie: false, takesFour: false };
+          if (!form) {
+            console.error("buildSkillRollDialog: form element not found in dialog; using defaults");
+            return { cardDice: 0, bankDice: 0, coolDice: 0, talentDie: false, takesFour: false };
+          }
           const data = new FormData(form);
           const cardDice = data.has("cardDice") ? opts.availableCardDice : 0;
           const bankDice = Math.min(Number(data.get("bankDice") ?? 0), opts.availableBank);

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -257,6 +257,7 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
 
   const result = await foundry.applications.api.DialogV2.wait({
     window: { title: `${i18n?.localize("INSPECTRES.SkillRoll") ?? "Skill Roll"}: ${opts.skillName}` },
+    rejectClose: false,
     content,
     buttons: [
       {

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -26,6 +26,11 @@ declare namespace foundry.applications.api {
     actions?: Record<string, (event: Event, target: HTMLElement) => void | Promise<void>>;
   }
 
+  interface ApplicationV2Part {
+    template: string;
+    scrollable?: string[];
+  }
+
   /** Base class for all V2 applications. */
   class ApplicationV2 {
     /** Logical application identifier — set in DEFAULT_OPTIONS.id, not the DOM element id. */
@@ -34,26 +39,43 @@ declare namespace foundry.applications.api {
     /** The outermost DOM element rendered by this application. */
     readonly element: HTMLElement;
 
+    static DEFAULT_OPTIONS: ApplicationV2Options;
+    static PARTS: Record<string, ApplicationV2Part>;
+
     render(options?: { force?: boolean; position?: ApplicationV2Options["position"] }): Promise<ApplicationV2>;
     close(options?: { animate?: boolean }): Promise<ApplicationV2>;
     setPosition(position: ApplicationV2Options["position"]): ApplicationV2Options["position"];
+
+    _prepareContext(options: ApplicationV2Options): Promise<Record<string, unknown>>;
+    _onRender(context: Record<string, unknown>, options: ApplicationV2Options): Promise<void>;
+  }
+
+  interface DialogV2Button {
+    action: string;
+    label: string;
+    icon?: string;
+    default?: boolean;
+    callback?: (event: Event, button: HTMLButtonElement, dialog: HTMLDialogElement) => unknown;
   }
 
   /** Modal/modeless dialog built on ApplicationV2. */
   class DialogV2 extends ApplicationV2 {
+    static wait(config: {
+      content: string;
+      window?: { title?: string };
+      position?: ApplicationV2Options["position"];
+      rejectClose?: boolean;
+      modal?: boolean;
+      buttons?: DialogV2Button[];
+    }): Promise<unknown>;
+
     static prompt(config: {
       content: string;
       window?: { title?: string };
       position?: ApplicationV2Options["position"];
       rejectClose?: boolean;
       modal?: boolean;
-      buttons?: Array<{
-        action: string;
-        label: string;
-        icon?: string;
-        default?: boolean;
-        callback?: (event: Event, button: HTMLButtonElement, dialog: HTMLDialogElement) => unknown;
-      }>;
+      buttons?: DialogV2Button[];
     }): Promise<unknown>;
 
     static confirm(config: {
@@ -62,6 +84,27 @@ declare namespace foundry.applications.api {
       rejectClose?: boolean;
       modal?: boolean;
     }): Promise<boolean>;
+  }
+}
+
+declare namespace foundry.applications.sheets {
+  interface ActorSheetV2Options extends foundry.applications.api.ApplicationV2Options {
+    document?: Actor;
+  }
+
+  /** Base class for V2 actor sheets. */
+  class ActorSheetV2 extends foundry.applications.api.ApplicationV2 {
+    readonly actor: Actor;
+    readonly isEditable: boolean;
+
+    static DEFAULT_OPTIONS: foundry.applications.api.ApplicationV2Options & {
+      actions?: Record<string, (this: ActorSheetV2, event: Event, target: HTMLElement) => void | Promise<void>>;
+    };
+
+    static PARTS: Record<string, { template: string; scrollable?: string[] }>;
+
+    _prepareContext(options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>>;
+    _onRender(context: Record<string, unknown>, options: foundry.applications.api.ApplicationV2Options): Promise<void>;
   }
 }
 

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -7,6 +7,12 @@
  * Reference: https://foundryvtt.com/api/v12/classes/foundry.applications.api.ApplicationV2.html
  */
 
+/** Foundry's extended FormData class — available as a global in V13+. */
+declare class FormDataExtended extends FormData {
+  readonly object: Record<string, unknown>;
+  readonly dtypes: Record<string, string>;
+}
+
 declare namespace foundry.applications.api {
   interface ApplicationV2Options {
     id?: string;
@@ -24,6 +30,11 @@ declare namespace foundry.applications.api {
       left?: number;
     };
     actions?: Record<string, (event: Event, target: HTMLElement) => void | Promise<void>>;
+    form?: {
+      handler?: (event: Event, form: HTMLFormElement, formData: FormDataExtended) => void | Promise<void>;
+      submitOnChange?: boolean;
+      closeOnSubmit?: boolean;
+    };
   }
 
   interface ApplicationV2Part {

--- a/foundry/system.json
+++ b/foundry/system.json
@@ -4,7 +4,7 @@
   "description": "Paranormal investigation RPG system for Foundry VTT.",
   "version": "0.2.0",
   "compatibility": {
-    "minimum": "12",
+    "minimum": "13",
     "verified": "14"
   },
   "authors": [

--- a/foundry/tsconfig.json
+++ b/foundry/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "lib": ["esnext", "dom"],
+    "lib": ["esnext", "dom", "dom.iterable"],
     "moduleResolution": "bundler",
     "types": ["fvtt-types", "node"],
     "strict": true,


### PR DESCRIPTION
## Summary

- All sheets and dialogs now use ApplicationV2/ActorSheetV2 APIs, targeting Foundry V13+
- `AgentSheet` and `FranchiseSheet` extend `foundry.applications.sheets.ActorSheetV2`
- `MissionTrackerApp` extends `foundry.applications.api.ApplicationV2`
- Roll dialogs use `foundry.applications.api.DialogV2.wait()` with array-style buttons
- `renderDialog` hook replaced with `renderDialogV2`
- Minimum Foundry version bumped to 13 in `system.json`

## Fixes included

**P1 — Logic / correctness**

- `for...of` replaces all `NodeListOf` iteration in `AgentSheet._onRender`; added `dom.iterable` to tsconfig lib
- `.catch()` handlers added to all fire-and-forget `render()` calls in `MissionTrackerApp`; broken instance reset on open failure
- `rejectClose: false` added to all three `DialogV2.wait()` calls to prevent spurious "Roll failed" toasts on ESC
- `console.error` logging added when dialog form element is not found in `DialogV2` callbacks
- `form: { submitOnChange: true, closeOnSubmit: false }` added to both sheet `DEFAULT_OPTIONS` so `<input name="system.*">` fields persist on change
- `toggleCool` converted from manual `_onRender` listener to a registered static action handler in `DEFAULT_OPTIONS.actions`

## Deferred work

- #51 — Extract shared async error handler (P2, simplification)
- #52 — Add test coverage for DialogV2 cancel/close paths and `_onRender` listeners (P2, test gap)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)