### PR TITLE
Sprint: TypeDataModel migration, CSS consolidation, and i18n (#63)

### DIFF
--- a/foundry/src/__mocks__/setup.ts
+++ b/foundry/src/__mocks__/setup.ts
@@ -209,7 +209,24 @@ Object.assign(globalThis, {
   loadTemplates,
   foundry: {
     abstract: {
-      TypeDataModel: class {},
+      TypeDataModel: class {
+        static defineSchema(): Record<string, unknown> { return {}; }
+      },
+    },
+    data: {
+      fields: {
+        StringField: class { constructor(opts?: unknown) { void opts; } },
+        NumberField: class { constructor(opts?: unknown) { void opts; } },
+        BooleanField: class { constructor(opts?: unknown) { void opts; } },
+        ArrayField: class { constructor(element?: unknown, opts?: unknown) { void element; void opts; } },
+        SchemaField: class {
+          fields: Record<string, unknown>;
+          constructor(fields: Record<string, unknown>, opts?: unknown) {
+            this.fields = fields;
+            void opts;
+          }
+        },
+      },
     },
     utils: {
       mergeObject: (target: Record<string, unknown>, source: Record<string, unknown>) => {

--- a/foundry/src/agent/agent-sheet.hbs
+++ b/foundry/src/agent/agent-sheet.hbs
@@ -1,4 +1,4 @@
-<form class="inspectres-sheet inspectres-agent-sheet" autocomplete="off">
+<form class="inspectres inspectres-sheet inspectres-agent-sheet" autocomplete="off">
   <!-- Header -->
   <header class="inspectres-header">
     <div class="sheet-header">
@@ -74,7 +74,7 @@
       <div class="cool-tracker">
         {{#if system.isWeird}}
           <div class="cool-counter">
-            <span class="cool-label">Unlimited Cool</span>
+            <span class="cool-label">{{localize "INSPECTRES.CoolUnlimited"}}</span>
             <input
               type="number"
               name="system.cool"

--- a/foundry/src/data/AgentDataModel.test.ts
+++ b/foundry/src/data/AgentDataModel.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+// RED: These tests will fail until AgentDataModel is implemented.
+// They verify the schema shape and default values match template.json.
+
+describe("AgentDataModel", () => {
+  it("module exports AgentDataModel", async () => {
+    const mod = await import("./AgentDataModel.js");
+    expect(mod.AgentDataModel).toBeDefined();
+  });
+
+  it("defineSchema returns all required skill fields", async () => {
+    const { AgentDataModel } = await import("./AgentDataModel.js");
+    const schema = AgentDataModel.defineSchema();
+    expect(schema).toHaveProperty("skills");
+    const skills = (schema["skills"] as { fields: Record<string, unknown> }).fields;
+    expect(skills).toHaveProperty("academics");
+    expect(skills).toHaveProperty("athletics");
+    expect(skills).toHaveProperty("technology");
+    expect(skills).toHaveProperty("contact");
+  });
+
+  it("defineSchema includes all top-level agent fields", async () => {
+    const { AgentDataModel } = await import("./AgentDataModel.js");
+    const schema = AgentDataModel.defineSchema();
+    expect(schema).toHaveProperty("talent");
+    expect(schema).toHaveProperty("cool");
+    expect(schema).toHaveProperty("isWeird");
+    expect(schema).toHaveProperty("characteristics");
+    expect(schema).toHaveProperty("missionPool");
+    expect(schema).toHaveProperty("description");
+  });
+});

--- a/foundry/src/data/AgentDataModel.ts
+++ b/foundry/src/data/AgentDataModel.ts
@@ -1,0 +1,37 @@
+const { StringField, NumberField, BooleanField, ArrayField, SchemaField } = foundry.data.fields;
+
+// fvtt-types v13 requires 2-4 type arguments for TypeDataModel; use AnyTypeDataModel
+// to avoid specifying Schema/Parent generics until DataModelConfig migration is complete.
+export class AgentDataModel extends (foundry.abstract.TypeDataModel as unknown as new () => object) {
+  static defineSchema(): Record<string, unknown> {
+    return {
+      description: new StringField({ required: true, initial: "" }),
+      skills: new SchemaField({
+        academics: new SchemaField({
+          base: new NumberField({ required: true, integer: true, min: 0, max: 4, initial: 2 }),
+          penalty: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+        }),
+        athletics: new SchemaField({
+          base: new NumberField({ required: true, integer: true, min: 0, max: 4, initial: 2 }),
+          penalty: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+        }),
+        technology: new SchemaField({
+          base: new NumberField({ required: true, integer: true, min: 0, max: 4, initial: 2 }),
+          penalty: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+        }),
+        contact: new SchemaField({
+          base: new NumberField({ required: true, integer: true, min: 0, max: 4, initial: 2 }),
+          penalty: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+        }),
+      }),
+      talent: new StringField({ required: true, initial: "" }),
+      cool: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+      isWeird: new BooleanField({ required: true, initial: false }),
+      characteristics: new ArrayField(new SchemaField({
+        text: new StringField({ required: true, initial: "" }),
+        used: new BooleanField({ required: true, initial: false }),
+      })),
+      missionPool: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+    };
+  }
+}

--- a/foundry/src/data/FranchiseDataModel.test.ts
+++ b/foundry/src/data/FranchiseDataModel.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+describe("FranchiseDataModel", () => {
+  it("module exports FranchiseDataModel", async () => {
+    const mod = await import("./FranchiseDataModel.js");
+    expect(mod.FranchiseDataModel).toBeDefined();
+  });
+
+  it("defineSchema includes cards sub-schema", async () => {
+    const { FranchiseDataModel } = await import("./FranchiseDataModel.js");
+    const schema = FranchiseDataModel.defineSchema();
+    expect(schema).toHaveProperty("cards");
+    const cards = (schema["cards"] as { fields: Record<string, unknown> }).fields;
+    expect(cards).toHaveProperty("library");
+    expect(cards).toHaveProperty("gym");
+    expect(cards).toHaveProperty("credit");
+  });
+
+  it("defineSchema includes all top-level franchise fields", async () => {
+    const { FranchiseDataModel } = await import("./FranchiseDataModel.js");
+    const schema = FranchiseDataModel.defineSchema();
+    expect(schema).toHaveProperty("bank");
+    expect(schema).toHaveProperty("missionPool");
+    expect(schema).toHaveProperty("missionGoal");
+    expect(schema).toHaveProperty("debtMode");
+    expect(schema).toHaveProperty("loanAmount");
+    expect(schema).toHaveProperty("description");
+  });
+});

--- a/foundry/src/data/FranchiseDataModel.ts
+++ b/foundry/src/data/FranchiseDataModel.ts
@@ -1,0 +1,21 @@
+const { StringField, NumberField, BooleanField, SchemaField } = foundry.data.fields;
+
+// fvtt-types v13 requires 2-4 type arguments for TypeDataModel; use unknown cast
+// to avoid specifying Schema/Parent generics until DataModelConfig migration is complete.
+export class FranchiseDataModel extends (foundry.abstract.TypeDataModel as unknown as new () => object) {
+  static defineSchema(): Record<string, unknown> {
+    return {
+      description: new StringField({ required: true, initial: "" }),
+      cards: new SchemaField({
+        library: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+        gym: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+        credit: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+      }),
+      bank: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+      missionPool: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+      missionGoal: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+      debtMode: new BooleanField({ required: true, initial: false }),
+      loanAmount: new NumberField({ required: true, integer: true, min: 0, initial: 0 }),
+    };
+  }
+}

--- a/foundry/src/franchise/franchise-sheet.hbs
+++ b/foundry/src/franchise/franchise-sheet.hbs
@@ -1,4 +1,4 @@
-<form class="inspectres-sheet inspectres-franchise-sheet" autocomplete="off">
+<form class="inspectres inspectres-sheet inspectres-franchise-sheet" autocomplete="off">
   <!-- Header -->
   <header class="inspectres-header">
     <div class="sheet-header">

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -7,6 +7,8 @@ import { InSpectresAgent } from "./agent/InSpectresAgent.js";
 import { AgentSheet } from "./agent/AgentSheet.js";
 import { InSpectresFranchise } from "./franchise/InSpectresFranchise.js";
 import { FranchiseSheet } from "./franchise/FranchiseSheet.js";
+import { AgentDataModel } from "./data/AgentDataModel.js";
+import { FranchiseDataModel } from "./data/FranchiseDataModel.js";
 import { registerHandlebarsHelpers } from "./utils/handlebars-helpers.js";
 import { MissionTrackerApp } from "./mission/MissionTrackerApp.js";
 import { onMissionSocketEvent } from "./mission/socket.js";
@@ -25,6 +27,13 @@ Hooks.once("init", async function () {
     console.error("Failed to load templates:", message);
     ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorTemplateLoad") ?? `Template load failed: ${message}`);
   }
+
+  // Register TypeDataModel classes — provides server-side validation and typed actor.system
+  // fvtt-types v13: CONFIG.Actor.dataModels not typed; cast through unknown to assign
+  (CONFIG.Actor as unknown as { dataModels: Record<string, unknown> }).dataModels = {
+    agent: AgentDataModel,
+    franchise: FranchiseDataModel,
+  };
 
   // Register per-type actor document classes (Foundry V12+)
   // fvtt-types doesn't know about documentClasses; cast through unknown to assign

--- a/foundry/src/lang/en.json
+++ b/foundry/src/lang/en.json
@@ -78,6 +78,13 @@
     "WarnBankRollDebtMode": "Bank rolls are disabled in Debt Mode.",
     "WarnClientRollDebtMode": "Client rolls are disabled in Debt Mode.",
     "Roll": "Roll",
-    "PenaltyFromStress": "penalty from stress"
+    "PenaltyFromStress": "penalty from stress",
+    "CoolUnlimited": "Unlimited Cool",
+    "RollCardTookFour": "Took a 4 — automatic Fair result.",
+    "PenaltyNote": {
+      "Minor": "Reduce 1 die from one skill of your choice on your character sheet.",
+      "Major": "Reduce 2 dice from one skill, or 1 die from each of two skills on your character sheet.",
+      "Meltdown": "Meltdown! Cool dice reset to 0. Reduce {count} skill dice total (distributed as you choose) on your character sheet."
+    }
   }
 }

--- a/foundry/src/mission/mission-tracker.hbs
+++ b/foundry/src/mission/mission-tracker.hbs
@@ -1,4 +1,4 @@
-<div class="inspectres-mission-tracker">
+<div class="inspectres inspectres-mission-tracker">
   <div class="tracker-header">
     {{localize "INSPECTRES.MissionTrackerTitle"}}
   </div>

--- a/foundry/src/rolls/penalty-note.test.ts
+++ b/foundry/src/rolls/penalty-note.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { buildPenaltyNote } from "./roll-executor.js";
+
+// RED: buildPenaltyNote is not yet exported and does not return i18n keys.
+// These tests will fail until:
+// 1. buildPenaltyNote is exported
+// 2. It returns i18n keys instead of raw English strings
+
+describe("buildPenaltyNote", () => {
+  it("returns INSPECTRES.PenaltyNote.Minor i18n key for face 3", () => {
+    const note = buildPenaltyNote(3, 1);
+    expect(note).toBe("INSPECTRES.PenaltyNote.Minor");
+  });
+
+  it("returns INSPECTRES.PenaltyNote.Major i18n key for face 2", () => {
+    const note = buildPenaltyNote(2, 1);
+    expect(note).toBe("INSPECTRES.PenaltyNote.Major");
+  });
+
+  it("returns localized meltdown message for face 1", () => {
+    // face 1 = Meltdown — uses game.i18n.format with {count} substitution
+    // mock returns the key, so result will be the formatted key string
+    const note = buildPenaltyNote(1, 3);
+    expect(note).toBe("INSPECTRES.PenaltyNote.Meltdown");
+  });
+});

--- a/foundry/src/rolls/roll-card.hbs
+++ b/foundry/src/rolls/roll-card.hbs
@@ -3,7 +3,7 @@
 
   {{#if (eq rollType "skill")}}
     {{#if takesFour}}
-      <p class="roll-card-note">Took a 4 — automatic Fair result.</p>
+      <p class="roll-card-note">{{localize "INSPECTRES.RollCardTookFour"}}</p>
     {{/if}}
     <div class="roll-card-outcome">
       <span class="roll-card-result">{{result}}</span>

--- a/foundry/src/rolls/roll-card.hbs
+++ b/foundry/src/rolls/roll-card.hbs
@@ -43,7 +43,7 @@
       <p class="roll-card-narration">{{narration}}</p>
     </div>
     {{#if penaltyNote}}
-      <p class="roll-card-penalty-note">⚠ {{penaltyNote}}</p>
+      <p class="roll-card-penalty-note">⚠ {{localize penaltyNote}}</p>
     {{/if}}
   {{/if}}
 

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -369,14 +369,14 @@ export async function executeStressRoll(agent: RollActor, params: StressRollPara
   await postChatCard(content, speaker, [roll]);
 }
 
-function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): string {
+export function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): string {
   switch (face) {
     case 3:
-      return "Reduce 1 die from one skill of your choice on your character sheet.";
+      return game.i18n?.localize("INSPECTRES.PenaltyNote.Minor") ?? "INSPECTRES.PenaltyNote.Minor";
     case 2:
-      return "Reduce 2 dice from one skill, or 1 die from each of two skills on your character sheet.";
+      return game.i18n?.localize("INSPECTRES.PenaltyNote.Major") ?? "INSPECTRES.PenaltyNote.Major";
     case 1:
-      return `Meltdown! Cool dice reset to 0. Reduce ${stressDiceCount} skill dice total (distributed as you choose) on your character sheet.`;
+      return game.i18n?.format("INSPECTRES.PenaltyNote.Meltdown", { count: String(stressDiceCount) }) ?? "INSPECTRES.PenaltyNote.Meltdown";
   }
 }
 

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -377,6 +377,10 @@ export function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): stri
       return game.i18n?.localize("INSPECTRES.PenaltyNote.Major") ?? "INSPECTRES.PenaltyNote.Major";
     case 1:
       return game.i18n?.format("INSPECTRES.PenaltyNote.Meltdown", { count: String(stressDiceCount) }) ?? "INSPECTRES.PenaltyNote.Meltdown";
+    default: {
+      const _exhaustive: never = face;
+      throw new Error(`buildPenaltyNote: unexpected face value ${JSON.stringify(_exhaustive)}`);
+    }
   }
 }
 

--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -6,210 +6,221 @@
   --inspectres-accent: #e74c3c;
   --inspectres-light: #ecf0f1;
   --inspectres-dark: #1a252f;
+  --inspectres-disabled: #95a5a6;
+  --inspectres-label-muted: #555;
+  --inspectres-info-bg: #fef3cd;
+  --inspectres-info-border: #f0ad4e;
+  --inspectres-info-text: #856404;
+  --inspectres-inactive: #bdc3c7;
+  --inspectres-success: #27ae60;
 }
 
-/* Base sheet styles */
-.inspectres-sheet {
-  background: var(--inspectres-light);
-  border: 1px solid var(--inspectres-primary);
-}
+.inspectres {
+  /* Base sheet styles */
+  &.inspectres-sheet {
+    background: var(--inspectres-light);
+    border: 1px solid var(--inspectres-primary);
+  }
 
-.inspectres-header {
-  background: linear-gradient(135deg, var(--inspectres-primary), var(--inspectres-secondary));
-  color: white;
-  padding: 1rem;
-  border-radius: 4px 4px 0 0;
-}
+  .inspectres-header {
+    background: linear-gradient(135deg, var(--inspectres-primary), var(--inspectres-secondary));
+    color: white;
+    padding: 1rem;
+    border-radius: 4px 4px 0 0;
+  }
 
-.inspectres-section {
-  padding: 1rem;
-  border-bottom: 1px solid var(--inspectres-light);
-}
+  .inspectres-section {
+    padding: 1rem;
+    border-bottom: 1px solid var(--inspectres-light);
+  }
 
-.inspectres-section:last-child {
-  border-bottom: none;
-}
+  .inspectres-section:last-child {
+    border-bottom: none;
+  }
 
-/* Roll buttons */
-.inspectres-roll-button {
-  background: var(--inspectres-secondary);
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: background 0.2s;
-}
+  /* Roll buttons */
+  .inspectres-roll-button {
+    background: var(--inspectres-secondary);
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background 0.2s;
+  }
 
-.inspectres-roll-button:hover {
-  background: var(--inspectres-accent);
-}
+  .inspectres-roll-button:hover {
+    background: var(--inspectres-accent);
+  }
 
-.inspectres-roll-button:disabled {
-  background: #95a5a6;
-  cursor: not-allowed;
-}
+  .inspectres-roll-button:disabled {
+    background: var(--inspectres-disabled);
+    cursor: not-allowed;
+  }
 
-/* Skills grid — scoped under the agent sheet to override Foundry's global
-   button { width: 100% } and display: block resets */
-.inspectres-agent-sheet .skills-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
+  /* Skills grid — scoped under the agent sheet to override Foundry's global
+     button { width: 100% } and display: block resets */
+  &.inspectres-agent-sheet {
+    .skills-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
 
-.inspectres-agent-sheet .skill-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-}
+    .skill-row {
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+    }
 
-.inspectres-agent-sheet .skill-main-line {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
+    .skill-main-line {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
 
-.inspectres-agent-sheet .skill-name {
-  width: 6rem;
-  font-weight: bold;
-  flex-shrink: 0;
-}
+    .skill-name {
+      width: 6rem;
+      font-weight: bold;
+      flex-shrink: 0;
+    }
 
-.inspectres-agent-sheet .skill-stepper {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  flex-shrink: 0;
-}
+    .skill-stepper {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      flex-shrink: 0;
+    }
 
-.inspectres-agent-sheet .skill-step {
-  width: 1.4rem;
-  height: 1.4rem;
-  padding: 0;
-  line-height: 1;
-  font-size: 1rem;
-  background: var(--inspectres-primary);
-  color: white;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-  flex-shrink: 0;
-}
+    .skill-step {
+      width: 1.4rem;
+      height: 1.4rem;
+      padding: 0;
+      line-height: 1;
+      font-size: 1rem;
+      background: var(--inspectres-primary);
+      color: white;
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
 
-.inspectres-agent-sheet .skill-step:hover {
-  background: var(--inspectres-secondary);
-}
+    .skill-step:hover {
+      background: var(--inspectres-secondary);
+    }
 
-.inspectres-agent-sheet .skill-base-value {
-  width: 1.5rem;
-  text-align: center;
-  font-weight: bold;
-  font-size: 1rem;
-  flex-shrink: 0;
-}
+    .skill-base-value {
+      width: 1.5rem;
+      text-align: center;
+      font-weight: bold;
+      font-size: 1rem;
+      flex-shrink: 0;
+    }
 
-.inspectres-agent-sheet .skill-effective-value {
-  color: #555;
-  font-size: 0.85rem;
-  flex: 1;
-}
+    .skill-effective-value {
+      color: var(--inspectres-label-muted);
+      font-size: 0.85rem;
+      flex: 1;
+    }
 
-.inspectres-agent-sheet .skill-roll-button {
-  width: 1.6rem;
-  height: 1.6rem;
-  padding: 0;
-  margin-left: auto;
-  font-size: 0.9rem;
-  background: var(--inspectres-secondary);
-  color: white;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+    .skill-roll-button {
+      width: 1.6rem;
+      height: 1.6rem;
+      padding: 0;
+      margin-left: auto;
+      font-size: 0.9rem;
+      background: var(--inspectres-secondary);
+      color: white;
+      border: none;
+      border-radius: 3px;
+      cursor: pointer;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
 
-.inspectres-agent-sheet .skill-roll-button:hover {
-  background: var(--inspectres-accent);
-}
+    .skill-roll-button:hover {
+      background: var(--inspectres-accent);
+    }
 
-.inspectres-agent-sheet .skill-penalty-line {
-  padding-left: 6.75rem;
-  font-size: 0.8rem;
-  color: var(--inspectres-accent);
-  font-style: italic;
-}
+    .skill-penalty-line {
+      padding-left: 6.75rem;
+      font-size: 0.8rem;
+      color: var(--inspectres-accent);
+      font-style: italic;
+    }
+  }
 
-/* Debt mode warning banner */
-.inspectres-debt-warning {
-  background: #fef3cd;
-  border: 1px solid #f0ad4e;
-  border-radius: 4px;
-  padding: 0.5rem 1rem;
-  margin: 0.5rem 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-weight: bold;
-  color: #856404;
-}
+  /* Debt mode warning banner */
+  .inspectres-debt-warning {
+    background: var(--inspectres-info-bg);
+    border: 1px solid var(--inspectres-info-border);
+    border-radius: 4px;
+    padding: 0.5rem 1rem;
+    margin: 0.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-weight: bold;
+    color: var(--inspectres-info-text);
+  }
 
-/* Mission progress bar */
-.inspectres-progress-bar {
-  width: 100%;
-  height: 12px;
-  background: #bdc3c7;
-  border-radius: 6px;
-  overflow: hidden;
-  margin-top: 0.25rem;
-}
+  /* Mission progress bar */
+  .inspectres-progress-bar {
+    width: 100%;
+    height: 12px;
+    background: var(--inspectres-inactive);
+    border-radius: 6px;
+    overflow: hidden;
+    margin-top: 0.25rem;
+  }
 
-.inspectres-progress-fill {
-  height: 100%;
-  background: var(--inspectres-secondary);
-  border-radius: 6px;
-  transition: width 0.3s ease;
-  max-width: 100%;
-}
+  .inspectres-progress-fill {
+    height: 100%;
+    background: var(--inspectres-secondary);
+    border-radius: 6px;
+    transition: width 0.3s ease;
+    max-width: 100%;
+  }
 
-/* Mission tracker floating window */
-.inspectres-mission-tracker {
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
+  /* Mission tracker floating window */
+  &.inspectres-mission-tracker {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 
-.inspectres-mission-tracker .tracker-header {
-  text-align: center;
-  font-size: 1.1rem;
-  font-weight: bold;
-}
+    .tracker-header {
+      text-align: center;
+      font-size: 1.1rem;
+      font-weight: bold;
+    }
 
-.inspectres-mission-tracker .tracker-progress {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
+    .tracker-progress {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
 
-.inspectres-mission-tracker .tracker-stats {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.9rem;
-}
+    .tracker-stats {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.9rem;
+    }
 
-.inspectres-mission-tracker .tracker-actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: center;
-}
+    .tracker-actions {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+  }
 
-.inspectres-mission-complete {
-  color: #27ae60;
-  font-weight: bold;
-  text-align: center;
+  .inspectres-mission-complete {
+    color: var(--inspectres-success);
+    font-weight: bold;
+    text-align: center;
+  }
 }

--- a/foundry/template.json
+++ b/foundry/template.json
@@ -3,52 +3,6 @@
     "types": [
       "agent",
       "franchise"
-    ],
-    "agent": {
-      "templates": [
-        "base"
-      ],
-      "skills": {
-        "academics": {
-          "base": 2,
-          "penalty": 0
-        },
-        "athletics": {
-          "base": 2,
-          "penalty": 0
-        },
-        "technology": {
-          "base": 2,
-          "penalty": 0
-        },
-        "contact": {
-          "base": 2,
-          "penalty": 0
-        }
-      },
-      "talent": "",
-      "cool": 0,
-      "isWeird": false,
-      "characteristics": [],
-      "missionPool": 0
-    },
-    "franchise": {
-      "templates": [
-        "base"
-      ],
-      "cards": {
-        "library": 0,
-        "gym": 0,
-        "credit": 0
-      },
-      "bank": 0,
-      "missionPool": 0,
-      "missionGoal": 0,
-      "debtMode": false,
-      "loanAmount": 0
-    },
-    "base": {
-      "description": ""
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Migrates actor schemas from `template.json` to TypeScript `TypeDataModel` subclasses (`AgentDataModel`, `FranchiseDataModel`) registered in `CONFIG.Actor.dataModels`
- Scopes all CSS under `.inspectres {}` root and extracts 7 custom properties for theme compatibility
- Converts hardcoded English strings in roll cards and agent sheet to i18n keys in `lang/en.json`
- Fixes penalty note rendering: `buildPenaltyNote()` returns an i18n key; template now calls `{{localize penaltyNote}}`
- Adds exhaustive `default` guard to `buildPenaltyNote` switch

## Constituent issues

Closes #37 (TypeDataModel migration)
Closes #39 (CSS root scope)
Closes #35 (CSS custom properties)
Closes #34 (i18n localization)
Closes #63 (composite sprint issue)

## Test plan

- [ ] All 42 unit tests pass (`npx vitest run`)
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Stress roll chat card shows localized penalty text (not raw key string)
- [ ] Agent and franchise sheets render with correct CSS scoping
- [ ] DataModel field validation works in Foundry (field types enforced server-side)