### PR TITLE
Add isEditable guards to all sheet action handlers (#38)

### DIFF
--- a/foundry/src/agent/AgentSheet.test.ts
+++ b/foundry/src/agent/AgentSheet.test.ts
@@ -58,7 +58,6 @@ describe("AgentSheet", () => {
   describe("_onRender", () => {
     it("does not attach change listeners when sheet is not editable", async () => {
       const mockSheet = new MockActorSheetV2();
-      mockSheet.isEditable = false;
       const sheet = Object.create(AgentSheet.prototype);
       sheet.actor = mockSheet.actor;
       sheet.isEditable = false;

--- a/foundry/src/agent/AgentSheet.test.ts
+++ b/foundry/src/agent/AgentSheet.test.ts
@@ -12,6 +12,49 @@ describe("AgentSheet", () => {
     Hooks.clearAll();
   });
 
+  describe("action handlers — isEditable guard", () => {
+    function makeSheet(isEditable: boolean) {
+      const actor = new MockActorSheetV2().actor;
+      actor.system = { skills: { academics: { base: 2, penalty: 0 } }, cool: 1, characteristics: [] };
+      const sheet = Object.create(AgentSheet.prototype);
+      sheet.actor = actor;
+      sheet.isEditable = isEditable;
+      const updateSpy = vi.spyOn(actor, "update").mockResolvedValue(actor);
+      return { sheet, updateSpy };
+    }
+
+    it("onSkillStep does not update actor when not editable", async () => {
+      const { sheet, updateSpy } = makeSheet(false);
+      const target = document.createElement("button");
+      target.setAttribute("data-action", "skillIncrease");
+      target.setAttribute("data-skill", "academics");
+      await AgentSheet.onSkillStep.call(sheet, new Event("click"), target);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("onToggleCool does not update actor when not editable", async () => {
+      const { sheet, updateSpy } = makeSheet(false);
+      const target = document.createElement("button");
+      target.setAttribute("data-value", "1");
+      await AgentSheet.onToggleCool.call(sheet, new Event("click"), target);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("onAddCharacteristic does not update actor when not editable", async () => {
+      const { sheet, updateSpy } = makeSheet(false);
+      await AgentSheet.onAddCharacteristic.call(sheet, new Event("click"), document.createElement("button"));
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("onRemoveCharacteristic does not update actor when not editable", async () => {
+      const { sheet, updateSpy } = makeSheet(false);
+      const target = document.createElement("button");
+      target.setAttribute("data-idx", "0");
+      await AgentSheet.onRemoveCharacteristic.call(sheet, new Event("click"), target);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("_onRender", () => {
     it("does not attach change listeners when sheet is not editable", async () => {
       const mockSheet = new MockActorSheetV2();

--- a/foundry/src/agent/AgentSheet.test.ts
+++ b/foundry/src/agent/AgentSheet.test.ts
@@ -13,10 +13,35 @@ describe("AgentSheet", () => {
   });
 
   describe("_onRender", () => {
+    it("does not attach change listeners when sheet is not editable", async () => {
+      const mockSheet = new MockActorSheetV2();
+      mockSheet.isEditable = false;
+      const sheet = Object.create(AgentSheet.prototype);
+      sheet.actor = mockSheet.actor;
+      sheet.isEditable = false;
+
+      const checkbox = document.createElement("input");
+      checkbox.className = "weird-checkbox";
+      checkbox.type = "checkbox";
+
+      const querySelectorAllSpy = vi.fn(() => [checkbox]);
+      Object.defineProperty(sheet, "element", {
+        value: { querySelectorAll: querySelectorAllSpy },
+      });
+
+      const updateSpy = vi.spyOn(sheet.actor, "update").mockResolvedValue(sheet.actor);
+
+      await sheet._onRender({}, {});
+
+      checkbox.dispatchEvent(new Event("change"));
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
     it("attaches change listener to weird-checkbox elements", async () => {
       const mockActor = new MockActorSheetV2().actor;
       const sheet = Object.create(AgentSheet.prototype);
       sheet.actor = mockActor;
+      sheet.isEditable = true;
 
       const checkbox = document.createElement("input");
       checkbox.className = "weird-checkbox";
@@ -40,6 +65,7 @@ describe("AgentSheet", () => {
       const mockActor = new MockActorSheetV2().actor;
       const sheet = Object.create(AgentSheet.prototype);
       sheet.actor = mockActor;
+      sheet.isEditable = true;
 
       const checkbox = document.createElement("input");
       checkbox.className = "weird-checkbox";
@@ -64,6 +90,7 @@ describe("AgentSheet", () => {
       const mockActor = new MockActorSheetV2().actor;
       const sheet = Object.create(AgentSheet.prototype);
       sheet.actor = mockActor;
+      sheet.isEditable = true;
 
       const checkbox1 = document.createElement("input");
       const checkbox2 = document.createElement("input");

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -14,7 +14,7 @@ function isSkillName(value: string | null): value is SkillName {
 }
 
 async function buildStressRollDialog(agent: Actor): Promise<void> {
-  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+  // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
   const system = agent.system as unknown as AgentData;
   const maxCool = system.cool;
 
@@ -86,7 +86,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
 
   override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
     const base = await super._prepareContext(_options);
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const system = this.actor.system as unknown as AgentData;
     return { ...base, system };
   }
@@ -105,7 +105,6 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
         });
       });
     }
-
   }
 
   static async onSkillRoll(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
@@ -142,7 +141,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       console.error("onSkillStep: missing or invalid data-skill attribute", { skillAttr });
       return;
     }
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const system = this.actor.system as unknown as AgentData;
     const skillData = system.skills[skillAttr];
     if (!skillData) {
@@ -172,7 +171,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       console.error("onToggleCool: invalid data-value", { valueStr });
       return;
     }
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const currentCool = (this.actor.system as unknown as AgentData).cool;
     const newCool = currentCool >= pipValue ? pipValue - 1 : pipValue;
     // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
@@ -184,7 +183,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
 
   static async onAddCharacteristic(this: AgentSheet, _event: Event, _target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const currentSystem = this.actor.system as unknown as AgentData;
     const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
     // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
@@ -206,7 +205,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       console.error("onRemoveCharacteristic: invalid data-idx value", { idxStr });
       return;
     }
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const currentSystem = this.actor.system as unknown as AgentData;
     const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
     // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -136,6 +136,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onSkillStep(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
     const skillAttr = target.getAttribute("data-skill");
     if (!isSkillName(skillAttr)) {
       console.error("onSkillStep: missing or invalid data-skill attribute", { skillAttr });
@@ -160,6 +161,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onToggleCool(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
     const valueStr = target.getAttribute("data-value");
     if (valueStr == null) {
       console.error("onToggleCool: missing data-value attribute");
@@ -181,6 +183,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onAddCharacteristic(this: AgentSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
     // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const currentSystem = this.actor.system as unknown as AgentData;
     const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
@@ -192,6 +195,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onRemoveCharacteristic(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
     const idxStr = target.getAttribute("data-idx");
     if (idxStr == null) {
       console.error("onRemoveCharacteristic: missing data-idx attribute");

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -14,6 +14,7 @@ function isSkillName(value: string | null): value is SkillName {
 }
 
 async function buildStressRollDialog(agent: Actor): Promise<void> {
+  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
   const system = agent.system as unknown as AgentData;
   const maxCool = system.cool;
 
@@ -85,16 +86,19 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
 
   override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
     const base = await super._prepareContext(_options);
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const system = this.actor.system as unknown as AgentData;
     return { ...base, system };
   }
 
   override async _onRender(context: Record<string, unknown>, options: foundry.applications.api.ApplicationV2Options): Promise<void> {
     await super._onRender(context, options);
+    if (!this.isEditable) return;
 
     // weird-checkbox: change event not covered by DEFAULT_OPTIONS.actions
     for (const el of this.element.querySelectorAll<HTMLInputElement>(".weird-checkbox")) {
       el.addEventListener("change", (event: Event) => {
+        // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
         const updateData = { "system.isWeird": (event.target as HTMLInputElement).checked } as unknown as Parameters<typeof this.actor.update>[0];
         void this.actor.update(updateData).catch((err: unknown) => {
           handleActionError(err, "Failed to toggle weird status", "INSPECTRES.ErrorUpdateFailed", "Failed to update actor data");
@@ -137,6 +141,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       console.error("onSkillStep: missing or invalid data-skill attribute", { skillAttr });
       return;
     }
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const system = this.actor.system as unknown as AgentData;
     const skillData = system.skills[skillAttr];
     if (!skillData) {
@@ -147,6 +152,7 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
     const delta = target.getAttribute("data-action") === "skillIncrease" ? 1 : -1;
     const next = Math.min(4, Math.max(0, current + delta));
     if (next === current) return;
+    // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
     const updateData = { [`system.skills.${skillAttr}.base`]: next } as unknown as Parameters<typeof this.actor.update>[0];
     void this.actor.update(updateData).catch((err: unknown) => {
       handleActionError(err, "Failed to update skill", "INSPECTRES.ErrorUpdateFailed", "Failed to update actor data");
@@ -164,8 +170,10 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       console.error("onToggleCool: invalid data-value", { valueStr });
       return;
     }
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const currentCool = (this.actor.system as unknown as AgentData).cool;
     const newCool = currentCool >= pipValue ? pipValue - 1 : pipValue;
+    // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
     const updateData = { "system.cool": newCool } as unknown as Parameters<typeof this.actor.update>[0];
     void this.actor.update(updateData).catch((err: unknown) => {
       handleActionError(err, "Failed to set cool dice", "INSPECTRES.ErrorUpdateFailed", "Failed to update actor data");
@@ -173,8 +181,10 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onAddCharacteristic(this: AgentSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const currentSystem = this.actor.system as unknown as AgentData;
     const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
+    // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
     const updateData = { "system.characteristics": [...characteristics, { text: "", used: false }] } as unknown as Parameters<typeof this.actor.update>[0];
     void this.actor.update(updateData).catch((err: unknown) => {
       handleActionError(err, "Failed to add characteristic", "INSPECTRES.ErrorAddCharacteristic", "Failed to add characteristic");
@@ -192,8 +202,10 @@ export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
       console.error("onRemoveCharacteristic: invalid data-idx value", { idxStr });
       return;
     }
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const currentSystem = this.actor.system as unknown as AgentData;
     const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
+    // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
     const updateData = { "system.characteristics": characteristics.filter((_: AgentCharacteristic, i: number) => i !== idx) } as unknown as Parameters<typeof this.actor.update>[0];
     void this.actor.update(updateData).catch((err: unknown) => {
       handleActionError(err, "Failed to remove characteristic", "INSPECTRES.ErrorRemoveCharacteristic", "Failed to remove characteristic");

--- a/foundry/src/franchise/FranchiseSheet.test.ts
+++ b/foundry/src/franchise/FranchiseSheet.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MockActorSheetV2, Hooks, ChatMessage } from "../__mocks__/setup.js";
+import { FranchiseSheet } from "./FranchiseSheet.js";
+
+describe("FranchiseSheet", () => {
+  beforeEach(() => {
+    Hooks.clearAll();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Hooks.clearAll();
+  });
+
+  describe("action handlers — isEditable guard", () => {
+    function makeSheet(isEditable: boolean) {
+      const actor = new MockActorSheetV2().actor;
+      actor.system = { bank: 3, debtMode: false, missionPool: 0, missionGoal: 5 };
+      const sheet = Object.create(FranchiseSheet.prototype);
+      sheet.actor = actor;
+      sheet.isEditable = isEditable;
+      const updateSpy = vi.spyOn(actor, "update").mockResolvedValue(actor);
+      return { sheet, updateSpy };
+    }
+
+    it("onBankRoll does not execute when sheet is not editable", async () => {
+      const { sheet, updateSpy } = makeSheet(false);
+      await FranchiseSheet.onBankRoll.call(sheet, new Event("click"), document.createElement("button"));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("onClientRoll does not post a chat message when sheet is not editable", async () => {
+      const { sheet } = makeSheet(false);
+      const chatSpy = vi.spyOn(ChatMessage, "create").mockResolvedValue({} as never);
+      await FranchiseSheet.onClientRoll.call(sheet, new Event("click"), document.createElement("button"));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(chatSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -21,6 +21,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
 
   override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
     const base = await super._prepareContext(_options);
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const system = this.actor.system as unknown as FranchiseData;
     const isGm = game.user?.isGM ?? false;
     const missionComplete = system.missionGoal > 0 && system.missionPool >= system.missionGoal;
@@ -28,6 +29,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onBankRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const system = this.actor.system as unknown as FranchiseData;
     if (system.debtMode) {
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnBankRollDebtMode") ?? "Bank rolls are disabled in Debt Mode.");
@@ -39,6 +41,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onClientRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const system = this.actor.system as unknown as FranchiseData;
     if (system.debtMode) {
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnClientRollDebtMode") ?? "Client rolls are disabled in Debt Mode.");

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -29,6 +29,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onBankRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
     // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const system = this.actor.system as unknown as FranchiseData;
     if (system.debtMode) {
@@ -41,6 +42,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
   }
 
   static async onClientRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
     // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
     const system = this.actor.system as unknown as FranchiseData;
     if (system.debtMode) {

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -21,7 +21,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
 
   override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
     const base = await super._prepareContext(_options);
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const system = this.actor.system as unknown as FranchiseData;
     const isGm = game.user?.isGM ?? false;
     const missionComplete = system.missionGoal > 0 && system.missionPool >= system.missionGoal;
@@ -30,7 +30,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
 
   static async onBankRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const system = this.actor.system as unknown as FranchiseData;
     if (system.debtMode) {
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnBankRollDebtMode") ?? "Bank rolls are disabled in Debt Mode.");
@@ -43,7 +43,7 @@ export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
 
   static async onClientRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+    // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
     const system = this.actor.system as unknown as FranchiseData;
     if (system.debtMode) {
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnClientRollDebtMode") ?? "Client rolls are disabled in Debt Mode.");

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -56,6 +56,7 @@ function extractFaces(roll: Roll): number[] {
 }
 
 async function actorUpdate(actor: RollActor, data: Record<string, unknown>): Promise<void> {
+  // fvtt-types expects full document data shape for actor.update; partial dot-notation paths are safe at runtime
   const updateData = data as unknown as Parameters<typeof actor.update>[0];
   await actor.update(updateData);
 }
@@ -71,6 +72,7 @@ async function postChatCard(
   speaker: ReturnType<typeof ChatMessage.getSpeaker>,
   rolls: Roll[],
 ): Promise<void> {
+  // fvtt-types ChatMessage.create expects strict DocumentData; whisper/rolls fields are valid at runtime
   await ChatMessage.create({ content, speaker, rolls } as unknown as Parameters<typeof ChatMessage.create>[0]);
 }
 
@@ -125,10 +127,12 @@ export async function executeSkillRoll(
   franchise: RollActor | null,
   skillName: SkillName,
 ): Promise<void> {
+  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
   const system = agent.system as unknown as AgentData;
   const skill = system.skills[skillName];
   const effectiveDice = Math.max(0, skill.base - skill.penalty);
 
+  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
   const franchiseSystem = franchise ? (franchise.system as unknown as FranchiseData) : null;
   const cardType = CARD_FOR_SKILL[skillName];
   const availableCardDice = franchiseSystem && cardType ? franchiseSystem.cards[cardType] : 0;
@@ -210,6 +214,7 @@ export async function executeSkillRoll(
     if (franchise.id !== null) emitMissionPoolUpdated(franchise.id);
   }
 
+  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: agent as Actor });
   const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "skill",
@@ -304,6 +309,7 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
 // ---------------------------------------------------------------------------
 
 export async function executeBankRoll(franchise: RollActor): Promise<void> {
+  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
   const system = franchise.system as unknown as FranchiseData;
   const currentBank = system.bank;
 
@@ -317,6 +323,7 @@ export async function executeBankRoll(franchise: RollActor): Promise<void> {
 
   await actorUpdate(franchise, { "system.bank": summary.finalBankTotal });
 
+  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
   const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "bank",
@@ -332,6 +339,7 @@ export async function executeBankRoll(franchise: RollActor): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export async function executeStressRoll(agent: RollActor, params: StressRollParams): Promise<void> {
+  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
   const system = agent.system as unknown as AgentData;
   const { stressDiceCount, coolDiceUsed } = params;
 
@@ -354,6 +362,7 @@ export async function executeStressRoll(agent: RollActor, params: StressRollPara
     await actorUpdate(agent, { "system.cool": system.cool + outcome.coolGain });
   }
 
+  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: agent as Actor });
   const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "stress",
@@ -403,6 +412,7 @@ export async function executeClientRoll(franchise: RollActor): Promise<void> {
     generated[attr] = table[key] ?? "";
   }
 
+  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
   const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "client",
@@ -411,5 +421,6 @@ export async function executeClientRoll(franchise: RollActor): Promise<void> {
   });
   // Client roll results are GM prep — whisper to all GMs only
   const gmIds = (game.users?.filter((u) => u.isGM).map((u) => u.id).filter((id): id is string => id !== null)) ?? [];
+  // fvtt-types ChatMessage.create expects strict DocumentData; whisper/rolls fields are valid at runtime
   await ChatMessage.create({ content, speaker, rolls, whisper: gmIds } as unknown as Parameters<typeof ChatMessage.create>[0]);
 }

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -127,12 +127,12 @@ export async function executeSkillRoll(
   franchise: RollActor | null,
   skillName: SkillName,
 ): Promise<void> {
-  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+  // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
   const system = agent.system as unknown as AgentData;
   const skill = system.skills[skillName];
   const effectiveDice = Math.max(0, skill.base - skill.penalty);
 
-  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+  // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
   const franchiseSystem = franchise ? (franchise.system as unknown as FranchiseData) : null;
   const cardType = CARD_FOR_SKILL[skillName];
   const availableCardDice = franchiseSystem && cardType ? franchiseSystem.cards[cardType] : 0;
@@ -309,7 +309,7 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
 // ---------------------------------------------------------------------------
 
 export async function executeBankRoll(franchise: RollActor): Promise<void> {
-  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+  // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
   const system = franchise.system as unknown as FranchiseData;
   const currentBank = system.bank;
 
@@ -339,7 +339,7 @@ export async function executeBankRoll(franchise: RollActor): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export async function executeStressRoll(agent: RollActor, params: StressRollParams): Promise<void> {
-  // fvtt-types v13 + template.json: actor.system resolves to UnknownSystem; cast required until DataModelConfig migration
+  // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
   const system = agent.system as unknown as AgentData;
   const { stressDiceCount, coolDiceUsed } = params;
 


### PR DESCRIPTION
## Summary

- Adds `if (!this.isEditable) return;` to `AgentSheet._onRender` (prevents weird-checkbox listener attachment on read-only sheets)
- Adds the same guard to all four write-capable `DEFAULT_OPTIONS.actions` handlers in `AgentSheet`: `onSkillStep`, `onToggleCool`, `onAddCharacteristic`, `onRemoveCharacteristic`
- Adds the same guard to `FranchiseSheet.onBankRoll` and `FranchiseSheet.onClientRoll`
- Adds justification comments on all `as unknown as` and `as Actor` casts in the three touched files, explaining the fvtt-types v13 / template.json boundary constraint
- Creates `FranchiseSheet.test.ts` with editability guard tests; extends `AgentSheet.test.ts` with four new guard tests (one per write handler)
- Cosmetic: shortened repeated cast comment to pointer form; removed dead assignment in test fixture

## Test plan

- [ ] `npx vitest run` — 49 tests pass (was 43 before this PR; 6 new)
- [ ] `npx tsc --noEmit` — clean
- [ ] Open a franchise sheet as a player with limited permission; verify bank roll and client roll buttons are inert
- [ ] Open an agent sheet as a player with limited permission; verify skill steppers, cool pips, add/remove characteristic buttons are inert

Closes #38