### PR TITLE
Fix V13 sheet rendering, CSS theming, and dialog handling

### DIFF
--- a/.claude/rules/playwright-foundry.md
+++ b/.claude/rules/playwright-foundry.md
@@ -1,0 +1,188 @@
+---
+paths:
+  - "e2e/**"
+  - "**/*.spec.ts"
+  - "/tmp/inspect-*.js"
+---
+
+# Playwright + Foundry VTT Testing
+
+Use Playwright (`playwright` v1.59+ is installed globally) for browser-based inspection and
+end-to-end testing of the Foundry system. **Prefer this over the agent browser** — it runs
+headless, produces structured output, and is far faster.
+
+## Login boilerplate
+
+Every script starts the same way. Foundry takes ~6 seconds to finish loading after the join
+redirect:
+
+```js
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1920, height: 1080 } });
+
+  await page.goto('http://127.0.0.1:30000/join');
+  await page.selectOption('select[name="userid"]', { label: 'Gamemaster' }).catch(() => {});
+  await page.click('button[type="submit"]').catch(() => {});
+  await page.waitForTimeout(6000);   // Foundry's init hooks need time to fire
+
+  // ... your inspection or interaction code ...
+
+  await browser.close();
+})();
+```
+
+Run with `node /tmp/my-script.js`. No build step needed — `playwright` is a CommonJS require.
+
+## Accessing Foundry globals inside `page.evaluate`
+
+Everything inside `page.evaluate(() => { ... })` runs in the browser context and has full access
+to Foundry globals: `game`, `CONFIG`, `Hooks`, `ui`, `foundry`, `Actor`, etc.
+
+```js
+const result = await page.evaluate(async () => {
+  // Open first actor sheet
+  const actor = game.actors.contents[0];
+  actor.sheet.render(true);
+  await new Promise(r => setTimeout(r, 1500));   // wait for render
+
+  const el = document.querySelector('.application.sheet.inspectres');
+  const style = window.getComputedStyle(el);
+  return {
+    tag: el?.tagName,
+    classes: el?.className,
+    color: style.color,
+    bg: style.backgroundColor,
+    height: style.height,
+    overflow: style.overflow,
+    outerHTML: el?.outerHTML.slice(0, 800),
+  };
+});
+console.log(JSON.stringify(result, null, 2));
+```
+
+Anything returned from `page.evaluate` must be JSON-serializable. Wrap errors:
+
+```js
+const result = await page.evaluate(() => {
+  try {
+    // ...
+  } catch (e) {
+    return { error: e.message };
+  }
+});
+```
+
+## V13 ActorSheetV2 DOM structure
+
+Foundry V13's `ApplicationV2` renders actor sheets with this nesting:
+
+```
+form.application.sheet.inspectres.actor.<type>   ← outer app wrapper (Foundry-managed)
+  header.window-header                            ← title bar + close button
+  section.window-content                          ← scrollable content area (overflow:hidden by default)
+    form.inspectres.inspectres-sheet              ← our Handlebars template
+      header.inspectres-header
+      div.sheet-body
+        section.inspectres-section
+        ...
+```
+
+Key facts:
+- The **outer element is `<form>`**, not `<section>` — `.application.sheet` is the outer form.
+- `section.window-content` clips at the sheet's configured `height` with `overflow: hidden` by
+  default. Set `overflow-y: auto` on it to enable scrolling.
+- Classes in `DEFAULT_OPTIONS.classes` land on the outer `form.application`, not the inner form.
+- Foundry's dark theme sets `--color-text-primary` to a cream color — it bleeds into any element
+  without an explicit `color`. Always set `color` explicitly on inner sheet forms.
+
+## CSS inspection patterns
+
+### Ancestor walk — understand inheritance chain
+
+```js
+const ancestors = [];
+let el = document.querySelector('your-element');
+while (el && el !== document.body) {
+  const s = window.getComputedStyle(el);
+  ancestors.push({ tag: el.tagName, classes: el.className, color: s.color, bg: s.backgroundColor, overflow: s.overflow });
+  el = el.parentElement;
+}
+return ancestors;
+```
+
+### CSS variable resolution
+
+```js
+const style = window.getComputedStyle(document.documentElement);
+const val = style.getPropertyValue('--color-text-primary');
+// Returns resolved value or empty string if undefined
+```
+
+### Test `:has()` selectors
+
+```js
+const tests = ['dialog:has(form.dialog-form)', '.application:has(form)'];
+return Object.fromEntries(tests.map(sel => [sel, !!document.querySelector(sel)]));
+```
+
+## Interaction patterns
+
+### Open an actor sheet
+
+```js
+await page.evaluate(async () => {
+  const actor = game.actors.getName('My Actor') ?? game.actors.contents[0];
+  actor.sheet.render(true);
+  await new Promise(r => setTimeout(r, 1500));
+});
+```
+
+### Click buttons inside the sheet
+
+```js
+// Use page.click with scoped selectors
+await page.click('.application.sheet.inspectres [data-action="skillRoll"]');
+await page.waitForTimeout(500);
+```
+
+### Trigger Foundry UI actions from JS
+
+```js
+await page.evaluate(() => {
+  // Click actors tab
+  document.querySelector('[data-tab="actors"]')?.click();
+});
+await page.waitForTimeout(500);
+await page.click('#actors .create-entry[data-action="createEntry"]').catch(() => {});
+```
+
+### Check for chat messages
+
+```js
+const messages = await page.evaluate(() =>
+  game.messages.contents.map(m => ({ content: m.content, speaker: m.speaker }))
+);
+```
+
+## Temporary scripts
+
+Write one-off inspection scripts to `/tmp/inspect-<thing>.js` and run with `node`. Previous
+scripts in `/tmp/inspect-dialog*.js` have working login boilerplate — copy and adapt.
+
+Do not commit these scratch scripts. If a pattern proves durable, move it to `e2e/`.
+
+## Timing notes
+
+| Action | Wait |
+|--------|------|
+| Page load after join | 6000ms |
+| Sheet render | 1500ms |
+| Dialog open | 1000–2000ms |
+| Actor update propagation | 500ms |
+| CSS change (after build + browser refresh) | — (manual) |
+
+Avoid `waitForSelector` on Foundry UI elements unless you know the exact selector — Foundry's
+dynamic rendering makes selectors fragile. Prefer a fixed timeout after triggering an action.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,9 +4,9 @@ secrets:
 
 services:
   foundry:
-    # "release" tracks the latest stable Foundry release. Pin to a specific version
-    # (e.g. ghcr.io/felddy/foundryvtt:13.345) if you need reproducible deployments.
-    image: ghcr.io/felddy/foundryvtt:release
+    # Pinned to V13 — system.json minimum is 13, so we develop and verify against it.
+    # To upgrade to V14+: change to ghcr.io/felddy/foundryvtt:release
+    image: ghcr.io/felddy/foundryvtt:13
     hostname: foundry
     ports:
       - "30000:30000"

--- a/foundry/src/__mocks__/setup.ts
+++ b/foundry/src/__mocks__/setup.ts
@@ -237,6 +237,8 @@ Object.assign(globalThis, {
       api: {
         ApplicationV2: MockApplicationV2,
         DialogV2: MockDialogV2,
+        // Identity mixin — returns the base class unchanged so sheet class definitions type-check
+        HandlebarsApplicationMixin: <T>(Base: T): T => Base,
       },
       sheets: {
         ActorSheetV2: MockActorSheetV2,

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -64,7 +64,8 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
   await executeStressRoll(agent, params);
 }
 
-export class AgentSheet extends foundry.applications.sheets.ActorSheetV2 {
+// HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
+export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
   static override DEFAULT_OPTIONS = {
     classes: ["inspectres", "sheet", "actor", "agent"],
     position: { width: 600, height: 700 as number | "auto" },

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -40,7 +40,7 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
           const form = dialog.querySelector("form") as HTMLFormElement | null;
           if (!form) {
             console.error("buildStressRollDialog: form element not found in dialog");
-            return { stressDiceCount: 1, coolDiceUsed: 0 };
+            return null;
           }
           const data = new FormData(form);
           const stressDiceCount = Math.max(1, Math.min(5, Number(data.get("stressDice") ?? 1)));

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -3,7 +3,8 @@ import { executeBankRoll, executeClientRoll } from "../rolls/roll-executor.js";
 import { MissionTrackerApp } from "../mission/MissionTrackerApp.js";
 import { handleActionError } from "../utils/ui-errors.js";
 
-export class FranchiseSheet extends foundry.applications.sheets.ActorSheetV2 {
+// HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
+export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
   static override DEFAULT_OPTIONS = {
     classes: ["inspectres", "sheet", "actor", "franchise"],
     position: { width: 600, height: 600 as number | "auto" },

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -65,15 +65,15 @@ Hooks.once("init", async function () {
   });
 });
 
-// The Create Actor dialog defaults to a fixed height too small to show all fields.
-// renderDialogV2 fires for ApplicationV2-based dialogs (Foundry V13+).
-// Match on the select[name="type"] presence — unique to document-creation dialogs.
-// setPosition must be used instead of style.height because Foundry calls setPosition after
-// the hook fires and would overwrite any inline style change.
+// The Create Actor/Item dialog (DialogV2.prompt) can render at an incorrect height because
+// _updatePosition runs before the browser paints the form content. Re-measure after layout
+// by deferring setPosition to the next animation frame so the browser has committed the DOM.
 Hooks.on("renderDialogV2", function (app, html: HTMLElement) {
-  if (html.querySelector("select[name='type']")) {
-    // fvtt-types types the hook's app param as Any; cast through unknown to call setPosition
-    (app as unknown as foundry.applications.api.ApplicationV2).setPosition({ height: "auto" });
+  if (html.querySelector("form#document-create")) {
+    requestAnimationFrame(() => {
+      // fvtt-types types the hook's app param as Any; cast through unknown to call setPosition
+      (app as unknown as foundry.applications.api.ApplicationV2).setPosition({ height: "auto" });
+    });
   }
 });
 

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -65,18 +65,6 @@ Hooks.once("init", async function () {
   });
 });
 
-// The Create Actor/Item dialog (DialogV2.prompt) can render at an incorrect height because
-// _updatePosition runs before the browser paints the form content. Re-measure after layout
-// by deferring setPosition to the next animation frame so the browser has committed the DOM.
-Hooks.on("renderDialogV2", function (app, html: HTMLElement) {
-  if (html.querySelector("form#document-create")) {
-    requestAnimationFrame(() => {
-      // fvtt-types types the hook's app param as Any; cast through unknown to call setPosition
-      (app as unknown as foundry.applications.api.ApplicationV2).setPosition({ height: "auto" });
-    });
-  }
-});
-
 Hooks.once("ready", function () {
   onMissionSocketEvent(() => {
     if (MissionTrackerApp.instance) {

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -68,9 +68,12 @@ Hooks.once("init", async function () {
 // The Create Actor dialog defaults to a fixed height too small to show all fields.
 // renderDialogV2 fires for ApplicationV2-based dialogs (Foundry V13+).
 // Match on the select[name="type"] presence — unique to document-creation dialogs.
-Hooks.on("renderDialogV2", function (_app, html: HTMLElement) {
+// setPosition must be used instead of style.height because Foundry calls setPosition after
+// the hook fires and would overwrite any inline style change.
+Hooks.on("renderDialogV2", function (app, html: HTMLElement) {
   if (html.querySelector("select[name='type']")) {
-    html.style.height = "auto";
+    // fvtt-types types the hook's app param as Any; cast through unknown to call setPosition
+    (app as unknown as foundry.applications.api.ApplicationV2).setPosition({ height: "auto" });
   }
 });
 

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -46,12 +46,14 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
   }
 
   static async onBeginCleanUp(this: MissionTrackerApp, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!(game.user?.isGM ?? false)) return;
     void this.openDistributionDialog().catch((err: unknown) => {
-      handleActionError(err, "Distribution dialog failed", "INSPECTRES.ErrorRollFailed", "Operation failed");
+      handleActionError(err, "Distribution dialog failed", "INSPECTRES.ErrorUpdateFailed", "Failed to update actor data");
     });
   }
 
   static async onEndEarly(this: MissionTrackerApp, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!(game.user?.isGM ?? false)) return;
     void this.endEarly().catch((err: unknown) => {
       handleActionError(err, "End mission early failed", "INSPECTRES.ErrorUpdateFailed", "Failed to update actor data");
     });

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -281,8 +281,8 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
         callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
           const form = dialog.querySelector("form") as HTMLFormElement | null;
           if (!form) {
-            console.error("buildSkillRollDialog: form element not found in dialog; using defaults");
-            return { cardDice: 0, bankDice: 0, coolDice: 0, talentDie: false, takesFour: false };
+            console.error("buildSkillRollDialog: form element not found in dialog");
+            return null;
           }
           const data = new FormData(form);
           const cardDice = data.has("cardDice") ? opts.availableCardDice : 0;
@@ -381,11 +381,11 @@ export async function executeStressRoll(agent: RollActor, params: StressRollPara
 export function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): string {
   switch (face) {
     case 3:
-      return game.i18n?.localize("INSPECTRES.PenaltyNote.Minor") ?? "INSPECTRES.PenaltyNote.Minor";
+      return game.i18n?.localize("INSPECTRES.PenaltyNote.Minor") ?? "Minor consequence";
     case 2:
-      return game.i18n?.localize("INSPECTRES.PenaltyNote.Major") ?? "INSPECTRES.PenaltyNote.Major";
+      return game.i18n?.localize("INSPECTRES.PenaltyNote.Major") ?? "Major consequence";
     case 1:
-      return game.i18n?.format("INSPECTRES.PenaltyNote.Meltdown", { count: String(stressDiceCount) }) ?? "INSPECTRES.PenaltyNote.Meltdown";
+      return game.i18n?.format("INSPECTRES.PenaltyNote.Meltdown", { count: String(stressDiceCount) }) ?? `Meltdown (${stressDiceCount} stress dice)`;
     default: {
       const _exhaustive: never = face;
       throw new Error(`buildPenaltyNote: unexpected face value ${JSON.stringify(_exhaustive)}`);

--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -1,37 +1,125 @@
 /* InSpectres System Stylesheet */
 
 :root {
+  /* Brand */
   --inspectres-primary: #2c3e50;
   --inspectres-secondary: #3498db;
   --inspectres-accent: #e74c3c;
-  --inspectres-light: #ecf0f1;
+
+  /* Sheet chrome */
+  --inspectres-sheet-bg: #ecf0f1;
+  --inspectres-light: #ecf0f1;        /* alias kept for compatibility */
   --inspectres-dark: #1a252f;
-  --inspectres-disabled: #95a5a6;
+
+  /* Text — explicit so Foundry's theme cannot bleed in */
+  --inspectres-text: #191813;
   --inspectres-label-muted: #555;
+
+  /* Input surfaces — light bg, dark text, subtle border */
+  --inspectres-input-bg: #ffffff;
+  --inspectres-input-border: #b0bec5;
+
+  /* Button surfaces */
+  --inspectres-btn-bg: #dce3e8;
+  --inspectres-btn-color: var(--inspectres-text);
+  --inspectres-btn-border: #90a4ae;
+
+  /* State colors */
+  --inspectres-disabled: #95a5a6;
+  --inspectres-inactive: #bdc3c7;
+  --inspectres-success: #27ae60;
+
+  /* Info/warning banner */
   --inspectres-info-bg: #fef3cd;
   --inspectres-info-border: #f0ad4e;
   --inspectres-info-text: #856404;
-  --inspectres-inactive: #bdc3c7;
-  --inspectres-success: #27ae60;
 }
 
-.inspectres {
-  /* Base sheet styles */
-  &.inspectres-sheet {
-    background: var(--inspectres-light);
-    border: 1px solid var(--inspectres-primary);
+/* ─── Outer V2 shell ────────────────────────────────────────────────────── */
+
+/* V13 ActorSheetV2: outer wrapper is form.application, inner is section.window-content. */
+.application.sheet.inspectres .window-content {
+  overflow-y: auto;
+  padding: 0;
+}
+
+/* Inner form owns all colors — Foundry's theme must not bleed past this boundary. */
+.application.sheet.inspectres .window-content > form {
+  min-height: 100%;
+  color: var(--inspectres-text);
+  background: var(--inspectres-sheet-bg);
+}
+
+/* ─── Inner sheet reset ─────────────────────────────────────────────────── */
+
+.inspectres.inspectres-sheet {
+  background: var(--inspectres-sheet-bg);
+  border: 1px solid var(--inspectres-primary);
+  color: var(--inspectres-text);
+
+  /* Reset ALL text-bearing elements so Foundry's global rules can't win */
+  h1, h2, h3, h4, h5, h6,
+  p, span, label, legend {
+    color: var(--inspectres-text);
   }
 
+  /* Reset inputs: Foundry sets a dark bg globally; we want light inputs on our light sheet */
+  input[type="text"],
+  input[type="number"],
+  input[type="email"],
+  textarea,
+  select {
+    color: var(--inspectres-text);
+    background: var(--inspectres-input-bg);
+    border: 1px solid var(--inspectres-input-border);
+    border-radius: 3px;
+  }
+
+  /* Checkboxes: leave browser default rendering, just ensure label color is right */
+  input[type="checkbox"] {
+    accent-color: var(--inspectres-primary);
+  }
+
+  /* Generic buttons: override Foundry's dark button defaults.
+     Named buttons (.btn-add, .btn-remove, .cool-pip, roll/step buttons) are styled individually. */
+  button:not(.inspectres-roll-button):not(.skill-step):not(.skill-roll-button):not(.cool-pip):not(.btn-add):not(.btn-remove) {
+    color: var(--inspectres-btn-color);
+    background: var(--inspectres-btn-bg);
+    border: 1px solid var(--inspectres-btn-border);
+    border-radius: 3px;
+    cursor: pointer;
+
+    &:hover { background: #c8d6dd; }
+  }
+}
+
+/* ─── Sheet sections ────────────────────────────────────────────────────── */
+
+.inspectres {
   .inspectres-header {
     background: linear-gradient(135deg, var(--inspectres-primary), var(--inspectres-secondary));
     color: white;
     padding: 1rem;
     border-radius: 4px 4px 0 0;
+
+    /* Inputs inside the dark header get a glass treatment — must beat the sheet-level reset */
+    input[type="text"],
+    input[type="number"],
+    input[type="email"],
+    textarea {
+      color: white !important;
+      background: rgba(255, 255, 255, 0.15) !important;
+      border-color: rgba(255, 255, 255, 0.4) !important;
+
+      &::placeholder { color: rgba(255, 255, 255, 0.6); }
+    }
+
+    h1, h2, h3, p, span, label { color: white; }
   }
 
   .inspectres-section {
     padding: 1rem;
-    border-bottom: 1px solid var(--inspectres-light);
+    border-bottom: 1px solid var(--inspectres-input-border);
   }
 
   .inspectres-section:last-child {
@@ -48,19 +136,12 @@
     cursor: pointer;
     font-weight: bold;
     transition: background 0.2s;
+
+    &:hover { background: var(--inspectres-accent); }
+    &:disabled { background: var(--inspectres-disabled); cursor: not-allowed; }
   }
 
-  .inspectres-roll-button:hover {
-    background: var(--inspectres-accent);
-  }
-
-  .inspectres-roll-button:disabled {
-    background: var(--inspectres-disabled);
-    cursor: not-allowed;
-  }
-
-  /* Skills grid — scoped under the agent sheet to override Foundry's global
-     button { width: 100% } and display: block resets */
+  /* ── Agent sheet specifics ── */
   &.inspectres-agent-sheet {
     .skills-grid {
       display: flex;
@@ -105,10 +186,8 @@
       border-radius: 3px;
       cursor: pointer;
       flex-shrink: 0;
-    }
 
-    .skill-step:hover {
-      background: var(--inspectres-secondary);
+      &:hover { background: var(--inspectres-secondary); }
     }
 
     .skill-base-value {
@@ -140,10 +219,8 @@
       display: flex;
       align-items: center;
       justify-content: center;
-    }
 
-    .skill-roll-button:hover {
-      background: var(--inspectres-accent);
+      &:hover { background: var(--inspectres-accent); }
     }
 
     .skill-penalty-line {
@@ -152,6 +229,63 @@
       color: var(--inspectres-accent);
       font-style: italic;
     }
+
+    .cool-pip {
+      background: var(--inspectres-btn-bg);
+      color: var(--inspectres-text);
+      border: 1px solid var(--inspectres-btn-border);
+      border-radius: 50%;
+      width: 1.8rem;
+      height: 1.8rem;
+      padding: 0;
+      cursor: pointer;
+      font-size: 1rem;
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.15s, color 0.15s;
+
+      &.filled {
+        background: var(--inspectres-primary);
+        color: white;
+        border-color: var(--inspectres-primary);
+      }
+
+      &:hover { background: var(--inspectres-secondary); color: white; }
+    }
+
+    .btn-add {
+      background: var(--inspectres-success);
+      color: white;
+      border: none;
+      border-radius: 3px;
+      padding: 0.25rem 0.75rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+
+      &:hover { filter: brightness(1.1); }
+    }
+
+    .btn-remove {
+      background: transparent;
+      color: var(--inspectres-accent);
+      border: none;
+      cursor: pointer;
+      font-size: 0.85rem;
+      padding: 0 0.25rem;
+
+      &:hover { color: darken(var(--inspectres-accent), 15%); }
+    }
+
+    .characteristic-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .characteristic-text { flex: 1; }
   }
 
   /* Debt mode warning banner */
@@ -225,7 +359,9 @@
   }
 }
 
-/* Foundry's DialogV2 measures height before paint; ensure create-document dialog is tall enough */
-.application:has(form#document-create) {
+/* ─── DialogV2 create-document dialog ──────────────────────────────────── */
+
+/* Foundry measures height before paint; form.dialog-form is V13's class (no id). */
+.application:has(form.dialog-form) {
   height: auto !important;
 }

--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -224,3 +224,8 @@
     text-align: center;
   }
 }
+
+/* Foundry's DialogV2 measures height before paint; ensure create-document dialog is tall enough */
+.application:has(form#document-create) {
+  height: auto !important;
+}

--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -38,16 +38,18 @@
 /* ─── Outer V2 shell ────────────────────────────────────────────────────── */
 
 /* V13 ActorSheetV2: outer wrapper is form.application, inner is section.window-content. */
-.application.sheet.inspectres .window-content {
-  overflow-y: auto;
-  padding: 0;
-}
+.application.sheet.inspectres {
+  .window-content {
+    overflow-y: auto;
+    padding: 0;
 
-/* Inner form owns all colors — Foundry's theme must not bleed past this boundary. */
-.application.sheet.inspectres .window-content > form {
-  min-height: 100%;
-  color: var(--inspectres-text);
-  background: var(--inspectres-sheet-bg);
+    /* Inner form owns all colors — Foundry's theme must not bleed past this boundary. */
+    > form {
+      min-height: 100%;
+      color: var(--inspectres-text);
+      background: var(--inspectres-sheet-bg);
+    }
+  }
 }
 
 /* ─── Inner sheet reset ─────────────────────────────────────────────────── */

--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -275,7 +275,7 @@
       font-size: 0.85rem;
       padding: 0 0.25rem;
 
-      &:hover { color: darken(var(--inspectres-accent), 15%); }
+      &:hover { color: color-mix(in srgb, var(--inspectres-accent), black 20%); }
     }
 
     .characteristic-row {

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -98,6 +98,20 @@ declare namespace foundry.applications.api {
   }
 }
 
+declare namespace foundry.applications.api {
+  /**
+   * Mixin that provides Handlebars template rendering (_renderHTML / _replaceHTML) to an
+   * ApplicationV2 subclass. Required for any ApplicationV2-based sheet that uses PARTS.
+   *
+   * Usage: `class MySheet extends HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2)`
+   *
+   * fvtt-types v13 does not yet declare this mixin — declared here until the library catches up.
+   */
+  function HandlebarsApplicationMixin<TBase extends abstract new (...args: never[]) => ApplicationV2>(
+    Base: TBase,
+  ): TBase;
+}
+
 declare namespace foundry.applications.sheets {
   interface ActorSheetV2Options extends foundry.applications.api.ApplicationV2Options {
     document?: Actor;

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -104,6 +104,7 @@ declare namespace foundry.applications.api {
    * Usage: `class MySheet extends HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2)`
    *
    * fvtt-types v13 does not yet declare this mixin — declared here until the library catches up.
+   * Returns TBase unchanged so the subclass constructor type is preserved.
    */
   function HandlebarsApplicationMixin<TBase extends abstract new (...args: never[]) => ApplicationV2>(
     Base: TBase,

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -96,9 +96,7 @@ declare namespace foundry.applications.api {
       modal?: boolean;
     }): Promise<boolean>;
   }
-}
 
-declare namespace foundry.applications.api {
   /**
    * Mixin that provides Handlebars template rendering (_renderHTML / _replaceHTML) to an
    * ApplicationV2 subclass. Required for any ApplicationV2-based sheet that uses PARTS.

--- a/foundry/system.json
+++ b/foundry/system.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "14"
+    "verified": "13"
   },
   "authors": [
     {


### PR DESCRIPTION
## Summary

- Wire `HandlebarsApplicationMixin` into `AgentSheet` and `FranchiseSheet` — required in V13 for any `PARTS`-based sheet to render
- Add comprehensive CSS reset boundary at `.inspectres.inspectres-sheet` so Foundry's dark-theme rules (dark inputs, dark buttons, dark text) cannot bleed into the sheet
- Fix create-document dialog height clipping via CSS `:has(form.dialog-form)` — the V13 dialog form has no `id`
- Fix `overflow-y` on `.window-content` so sheet content is scrollable instead of clipped
- Replace `darken()` (Sass-only) with `color-mix()` for `.btn-remove` hover
- Merge duplicate `declare namespace foundry.applications.api` blocks in `foundry-v2.d.ts`
- Add `HandlebarsApplicationMixin` to test mock; all 49 tests pass
- `buildSkillRollDialog` and `buildStressRollDialog` now return `null` (cancel the roll) when the dialog's form element is missing, instead of fabricating inputs
- `buildPenaltyNote` fallback strings are now English instead of raw i18n keys
- Add `isGM` guard to `MissionTrackerApp.onBeginCleanUp` and `onEndEarly`; fix wrong error key `ErrorRollFailed` → `ErrorUpdateFailed` in `onBeginCleanUp`
- Nest outer-shell `.window-content` CSS selectors under `.application.sheet.inspectres`
- Pin Docker image and `system.json` verified to Foundry V13
- Document Playwright/Foundry testing patterns in `.claude/rules/playwright-foundry.md`

## Deferred

- #66 — Improve `HandlebarsApplicationMixin` return type to expose `_renderHTML`/`_replaceHTML` (blocked by TypeScript `TS2510` with abstract constructor intersections)

## Test plan

- [ ] All 49 vitest tests pass (`npx vitest run`)
- [ ] `tsc --noEmit` exits clean
- [ ] Agent sheet opens and shows dark text on light background in Foundry V13
- [ ] Franchise sheet opens and shows correct theming in Foundry V13
- [ ] Create Actor dialog renders at full height without clipping
- [ ] Sheet content is scrollable when taller than window height
- [ ] Skill and stress roll dialogs cancel cleanly when closed without filling the form