### PR TITLE
refactor: Improve HandlebarsApplicationMixin type documentation

### DIFF
--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -98,8 +98,8 @@ declare namespace foundry.applications.api {
   }
 
   /**
-   * Mixin that provides Handlebars template rendering (_renderHTML / _replaceHTML) to an
-   * ApplicationV2 subclass. Required for any ApplicationV2-based sheet that uses PARTS.
+   * Mixin that provides Handlebars template rendering to an ApplicationV2 subclass.
+   * Required for any ApplicationV2-based sheet that uses PARTS.
    *
    * Usage: `class MySheet extends HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2)`
    *
@@ -107,29 +107,12 @@ declare namespace foundry.applications.api {
    *
    * LIMITATION: TypeScript's mixin typing cannot express the type-level addition of _renderHTML
    * and _replaceHTML. At runtime, the mixin's prototype augmentation adds these methods safely,
-   * but TypeScript sees only the return type TBase.
-   *
-   * If you need to call these methods from sheet code, cast to ApplicationV2Handlebars (below).
-   * In practice, these methods are only called by ApplicationV2 internals, so user code rarely
-   * needs them. The mixin is required for PARTS support, not for direct method access.
+   * but TypeScript sees only the return type TBase. In practice, these methods are only called
+   * by ApplicationV2 internals, so user code rarely needs them directly.
    */
   function HandlebarsApplicationMixin<TBase extends abstract new (...args: never[]) => ApplicationV2>(
     Base: TBase,
   ): TBase;
-
-  /**
-   * Type marker for ApplicationV2 subclasses enhanced by HandlebarsApplicationMixin.
-   * Use this to cast when accessing mixin methods that TypeScript cannot statically resolve:
-   *
-   *     const app = this as ApplicationV2Handlebars;
-   *     const html = await app._renderHTML("part-id");
-   *
-   * In most cases this cast is not needed — ApplicationV2 internals manage the methods.
-   */
-  interface ApplicationV2Handlebars extends ApplicationV2 {
-    protected _renderHTML(partId: string): Promise<string>;
-    protected _replaceHTML(partId: string): Promise<void>;
-  }
 }
 
 declare namespace foundry.applications.sheets {

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -104,11 +104,32 @@ declare namespace foundry.applications.api {
    * Usage: `class MySheet extends HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2)`
    *
    * fvtt-types v13 does not yet declare this mixin — declared here until the library catches up.
-   * Returns TBase unchanged so the subclass constructor type is preserved.
+   *
+   * LIMITATION: TypeScript's mixin typing cannot express the type-level addition of _renderHTML
+   * and _replaceHTML. At runtime, the mixin's prototype augmentation adds these methods safely,
+   * but TypeScript sees only the return type TBase.
+   *
+   * If you need to call these methods from sheet code, cast to ApplicationV2Handlebars (below).
+   * In practice, these methods are only called by ApplicationV2 internals, so user code rarely
+   * needs them. The mixin is required for PARTS support, not for direct method access.
    */
   function HandlebarsApplicationMixin<TBase extends abstract new (...args: never[]) => ApplicationV2>(
     Base: TBase,
   ): TBase;
+
+  /**
+   * Type marker for ApplicationV2 subclasses enhanced by HandlebarsApplicationMixin.
+   * Use this to cast when accessing mixin methods that TypeScript cannot statically resolve:
+   *
+   *     const app = this as ApplicationV2Handlebars;
+   *     const html = await app._renderHTML("part-id");
+   *
+   * In most cases this cast is not needed — ApplicationV2 internals manage the methods.
+   */
+  interface ApplicationV2Handlebars extends ApplicationV2 {
+    protected _renderHTML(partId: string): Promise<string>;
+    protected _replaceHTML(partId: string): Promise<void>;
+  }
 }
 
 declare namespace foundry.applications.sheets {


### PR DESCRIPTION
## Summary

Fixed TypeScript compilation error in Foundry V2 type declarations. Resolved TS1070 error caused by invalid `protected` access modifiers on interface members, and removed unused `ApplicationV2Handlebars` interface that violated the "no speculative features" philosophy.

## Changes

- **foundry/src/types/foundry-v2.d.ts**: 
  - Removed `protected` keywords from `ApplicationV2Handlebars` interface methods (TS1070 syntax error)
  - Dropped entire `ApplicationV2Handlebars` interface (unused, incorrect method signatures, violates project philosophy)
  - Streamlined `HandlebarsApplicationMixin` documentation to clarify TypeScript's type system limitations

## Test Results

- ✓ `tsc --noEmit` — clean compilation
- ✓ All 70 tests pass
- ✓ No regressions in AgentSheet or FranchiseSheet

## Notes

The project avoids speculative features — the interface was added without a real call site and would need corrections before use anyway. The limitation exists in TypeScript's type system, not the runtime implementation, and is documented in the mixin JSDoc.

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)