### PR TITLE
refactor: consolidate listener cleanup & document i18n duplication

### DIFF
--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -7,6 +7,7 @@ import { executeSkillRoll, executeStressRoll, type SkillName } from "../rolls/ro
 import { findFranchiseActor, franchiseSystemData } from "../franchise/franchise-utils.js";
 import { handleActionError } from "../utils/ui-errors.js";
 import { activateTabs } from "../utils/sheet-tabs.js";
+import { getOrCreateListenerController } from "../utils/listener-cleanup.js";
 
 const SKILL_NAMES = ["academics", "athletics", "technology", "contact"] as const;
 
@@ -16,6 +17,7 @@ function isSkillName(value: string | null): value is SkillName {
 
 // Store AbortController for each sheet instance to manage checkbox listeners
 const checkboxControllers = new WeakMap<AgentSheet, AbortController>();
+
 
 async function buildStressRollDialog(agent: Actor): Promise<void> {
   // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
@@ -105,13 +107,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
 
     if (!this.isEditable) return;
 
-    // Abort previous listeners before attaching new ones (prevents accumulation on re-render)
-    const prevController = checkboxControllers.get(this);
-    if (prevController) {
-      prevController.abort();
-    }
-    const newController = new AbortController();
-    checkboxControllers.set(this, newController);
+    const controller = getOrCreateListenerController(checkboxControllers, this);
 
     // weird-checkbox: change event not covered by DEFAULT_OPTIONS.actions
     for (const el of this.element.querySelectorAll<HTMLInputElement>(".weird-checkbox")) {
@@ -121,7 +117,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
         void this.actor.update(updateData).catch((err: unknown) => {
           handleActionError(err, "Failed to toggle weird status", "INSPECTRES.ErrorUpdateFailed", "Failed to update actor data");
         });
-      }, { signal: newController.signal });
+      }, { signal: controller.signal });
     }
   }
 

--- a/foundry/src/rolls/roll-charts.ts
+++ b/foundry/src/rolls/roll-charts.ts
@@ -37,6 +37,15 @@ export const BANK_ROLL_CHART = {
  * Client Generation Table: Roll 2d6 for each of four attributes
  * This is NOT an outcome resolution table; it randomly generates client characteristics
  */
+/**
+ * Client Generation Table: Roll 2d6 for each of four attributes
+ * This is NOT an outcome resolution table; it randomly generates client characteristics
+ *
+ * NOTE: Both ClientType[2] and ClientOccurrence[2] map to "Ghost/Monster Transformation" in locale files.
+ * This duplication is intentional: they represent different semantic contexts of the same phenomenon.
+ * ClientType describes *what the client is*, ClientOccurrence describes *what happened to them*.
+ * Translators should use the same string for both keys to maintain narrative consistency.
+ */
 export const CLIENT_GENERATION_TABLE = {
   personality: {
     2: "INSPECTRES.ClientPersonality.Horny",

--- a/foundry/src/rolls/roll-charts.ts
+++ b/foundry/src/rolls/roll-charts.ts
@@ -36,10 +36,6 @@ export const BANK_ROLL_CHART = {
 /**
  * Client Generation Table: Roll 2d6 for each of four attributes
  * This is NOT an outcome resolution table; it randomly generates client characteristics
- */
-/**
- * Client Generation Table: Roll 2d6 for each of four attributes
- * This is NOT an outcome resolution table; it randomly generates client characteristics
  *
  * NOTE: Both ClientType[2] and ClientOccurrence[2] map to "Ghost/Monster Transformation" in locale files.
  * This duplication is intentional: they represent different semantic contexts of the same phenomenon.

--- a/foundry/src/utils/listener-cleanup.ts
+++ b/foundry/src/utils/listener-cleanup.ts
@@ -1,0 +1,15 @@
+/**
+ * Manage AbortController lifecycle for event listeners keyed by instance.
+ * Prevents listener accumulation across re-renders by aborting previous
+ * listeners before setting up new ones.
+ */
+export function getOrCreateListenerController<T extends object>(
+  controllers: WeakMap<T, AbortController>,
+  instance: T,
+): AbortController {
+  const prev = controllers.get(instance);
+  if (prev) prev.abort();
+  const next = new AbortController();
+  controllers.set(instance, next);
+  return next;
+}

--- a/foundry/src/utils/sheet-tabs.ts
+++ b/foundry/src/utils/sheet-tabs.ts
@@ -1,3 +1,5 @@
+import { getOrCreateListenerController } from "./listener-cleanup.js";
+
 // Keyed by element instance so previous listeners are aborted before re-attaching.
 const tabControllers = new WeakMap<HTMLElement, AbortController>();
 
@@ -28,9 +30,7 @@ export function activateTabs(element: HTMLElement, defaultTab: string): void {
 
   applyActiveTab(buttons, tabs, element, activeTab);
 
-  tabControllers.get(element)?.abort();
-  const controller = new AbortController();
-  tabControllers.set(element, controller);
+  const controller = getOrCreateListenerController(tabControllers, element);
   const { signal } = controller;
 
   const buttonArray = Array.from(buttons);


### PR DESCRIPTION
## Summary

Consolidates the repeated WeakMap + AbortController lifecycle pattern into a shared utility. Adds documentation explaining why GhostMonster i18n keys are intentionally duplicated across ClientType and ClientOccurrence arrays.

## Changes

- Extract `getOrCreateListenerController` utility to manage AbortController lifecycle keyed by instance
- Apply utility to AgentSheet checkbox listeners and sheet-tabs listeners, eliminating code duplication
- Document ClientType[2] / ClientOccurrence[2] GhostMonster duplication with translator note
- Fix: remove duplicate JSDoc block that was hiding the GhostMonster rationale

## Fixes

- Closes #103
- Closes #99
- Closes #100

## Deferred work

- Add unit tests for listener-cleanup utility: #104