### PR TITLE
docs: clarify main branch protection in rules

### DIFF
--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -86,6 +86,16 @@ Use these terms consistently. Don't invent synonyms.
 
 **Regular review.** When fixing a bug or adding a feature, check if docs need updating. If docs are out of sync with code, update docs immediately.
 
+## Workflow & Branching
+
+**Never commit directly to `main`.** The main branch is protected — all changes must go through feature branches and pull requests. Always:
+1. Create a feature branch (`fix/`, `docs/`, etc.)
+2. Make changes on that branch
+3. Create a PR for review
+4. Merge via PR only
+
+This ensures all documentation changes are reviewed before reaching production.
+
 ## Quality Checklist
 
 Before publishing:


### PR DESCRIPTION
## Summary

Add explicit requirement to documentation rules that main is protected and all changes must go through feature branches and pull requests.

## Changes

- Added "Workflow & Branching" section to `.claude/rules/documentation.md`
- Emphasizes never committing directly to main
- Clarifies PR-only merge policy