### PR TITLE
Clarify death roll audit trail exemption

### DIFF
--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -390,6 +390,7 @@ export async function executeStressRoll(
   let deathOutcome: DeathDismembermentOutcome | null = null;
   if (deathModeActive && effectiveFace <= 2) {
     // Death mode activated: roll d3 for death outcomes (1=Maimed, 2=Crippled, 3=Killed)
+    // Death roll is never auditable — use bare Math.random(); death outcome must be spontaneous (not replicable)
     const deathRoll = Math.floor(Math.random() * 3) + 1;
     if (deathRoll < 1 || deathRoll > 3) {
       throw new Error(`Invalid d3 result: ${deathRoll}`);


### PR DESCRIPTION
## Summary
Added comment explaining why death roll d3 generation uses bare Math.random() instead of Foundry's auditable Roll API: death outcomes must be spontaneous and non-replicable to preserve narrative integrity and prevent deterministic outcome exploitation.

## Changes
- Added 1-line comment to roll-executor.ts line 393 explaining the architectural decision

## Test Plan
- [x] Type check passes (tsc --noEmit)
- [x] All tests pass (vitest run, 130 tests)
- [x] Pre-PR review: code review, semgrep scan, simplification analysis, silent failure audit, variant pattern hunt

## Deferred Work
- GitHub issue #151: Pre-existing error handling issue in stress/skill rolls (silent failures, generic error messages). Not introduced by this PR; created as separate issue for future architectural refactoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)