### PR TITLE
docs: add GM control surface design principles

### DIFF
--- a/.claude/rules/foundry-sheets.md
+++ b/.claude/rules/foundry-sheets.md
@@ -167,6 +167,23 @@ const result = await foundry.applications.api.DialogV2.wait({
 if (!result) return;
 ```
 
+## GM Control Surfaces
+
+**Principle:** Game-critical operations must have visible UI buttons on sheets, not be hidden in settings or require console access.
+
+**When adding a new feature that GMs control:**
+1. If it affects gameplay rules, add a visible control/indicator to the relevant sheet
+2. Label it clearly in game terms, not technical jargon
+3. Group related controls (recovery controls on Agent sheet, financial on Franchise sheet)
+4. Never hide critical state behind code paths or auto-set it without override buttons
+
+**Examples:**
+- Agent recovery state (`isDead`, `daysOutOfAction`) → needs "Revive" button and recovery status display
+- Franchise debt/cards (`debtMode`, `cardsLocked`) → needs visible toggles/overrides on Franchise sheet
+- Mission end/vacation → needs direct button, not buried in Mission Tracker dialog
+
+See CLAUDE.md "GM Control Surface Design" for full principles.
+
 ## Anti-Patterns
 
 | Never do this | Do this instead |
@@ -181,3 +198,5 @@ if (!result) return;
 | `new Dialog(...)` / `Dialog.wait()` (V1, deprecated V13) | `foundry.applications.api.DialogV2.wait()` |
 | Registering sheets outside `init` hook | Always register in `Hooks.once("init", ...)` |
 | `extends ActorSheet` / `extends ItemSheet` (V1, deprecated V13) | `foundry.applications.sheets.ActorSheetV2` |
+| Game state controllable only via settings | Add direct button/control to relevant sheet |
+| Auto-setting critical flags with no override | Always provide GM button to change state |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,3 +176,41 @@ System uses `currentDay` (Foundry setting), not in-game combat rounds.
 **Prevents:**
 - Agents stuck in recovery (GM forgot to reset)
 - Stale `recoveryStartedAt` blocking recovery expiry
+
+## GM Control Surface Design
+
+### Principle: No Settings-Only Gameplay State
+
+Game-critical operations **must have discoverable UI buttons**, not require navigating Foundry settings or using console.
+
+**Why:** GMs need fast, confident access during play. Settings are for configuration (once per campaign), not moment-to-moment gameplay.
+
+**Rule:** If a flag affects gameplay (death mode, recovery state, debt mode, day counter, mission status), it must have:
+1. **Visible indicator** on the relevant sheet (what's the current state?)
+2. **Direct button/control** to change it (how do I adjust this?)
+3. **Clear labeling** (what does this do, in game terms not technical terms?)
+4. **Context-appropriate placement** (recovery controls on agent sheet, financial on franchise sheet, day on toolbar)
+
+### Examples
+
+✅ **Good:**
+- Agent sheet: "Status: Recovering (2 days left)" + "Revive Agent" button
+- Franchise sheet: Visible "Death Mode" checkbox + explanation
+- Toolbar: Day display + "+1 Day" / "-1 Day" buttons
+- Mission Tracker: "End Mission & Vacation" button
+
+❌ **Bad:**
+- `currentDay` only in Settings
+- `isDead` field with no UI to toggle
+- `cardsLocked` state auto-set by code, no override button
+- Vacation trigger requires navigation through Mission Tracker + dialog
+
+### Architecture Decision: Distributed vs. Centralized
+
+**Current approach (distributed):** Each control lives on its natural sheet (agent sheet for recovery, franchise sheet for financial).
+
+**Trade-off:** GMs must navigate multiple sheets during fast play.
+
+**If play-testing shows high access frequency:** Consider hybrid approach with toolbar widget for day/mission/vacation quick-access, keeping detailed controls on sheets.
+
+**See also:** GitHub issues #159–#168 (GM control audit results)


### PR DESCRIPTION
Document design pattern from codebase audit: game-critical operations must have discoverable UI buttons, not be settings-only or console-dependent.

Establishes requirements for GM-controlled features:
- Visible state indicator
- Direct control/button to change state
- Clear game-term labeling
- Context-appropriate sheet placement

Adds GM control surface anti-patterns to prevent future hidden operations.

See GitHub issues #159-#168 for identified gaps in current codebase.