### PR TITLE
feat: Bankruptcy Handler debt mechanics & repayment UI

### DIFF
--- a/foundry/src/franchise/FranchiseSheet.test.ts
+++ b/foundry/src/franchise/FranchiseSheet.test.ts
@@ -38,4 +38,49 @@ describe("FranchiseSheet", () => {
       expect(chatSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("debt control actions", () => {
+    function makeSheetWithGM(isGM: boolean, debtMode: boolean = false) {
+      const actor = new MockActorSheetV2().actor;
+      actor.system = { bank: 3, debtMode, cardsLocked: false, missionPool: 0, missionGoal: 5 };
+      const sheet = Object.create(FranchiseSheet.prototype);
+      sheet.actor = actor;
+      sheet.isEditable = true;
+      (globalThis as any).game = { user: { isGM } };
+      const updateSpy = vi.spyOn(actor, "update").mockResolvedValue(actor);
+      return { sheet, updateSpy };
+    }
+
+    it("onToggleDebtMode requires GM permission", async () => {
+      const { sheet, updateSpy } = makeSheetWithGM(false);
+      await FranchiseSheet.onToggleDebtMode.call(sheet, new Event("click"), document.createElement("button"));
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("onToggleDebtMode toggles debtMode when GM", async () => {
+      const { sheet, updateSpy } = makeSheetWithGM(true, false);
+      await FranchiseSheet.onToggleDebtMode.call(sheet, new Event("click"), document.createElement("button"));
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          "system.debtMode": true,
+        }),
+      );
+    });
+
+    it("onToggleCardsLocked requires GM permission", async () => {
+      const { sheet, updateSpy } = makeSheetWithGM(false, true);
+      await FranchiseSheet.onToggleCardsLocked.call(sheet, new Event("click"), document.createElement("button"));
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("onToggleCardsLocked toggles cardsLocked when GM", async () => {
+      const { sheet, updateSpy } = makeSheetWithGM(true, true);
+      await FranchiseSheet.onToggleCardsLocked.call(sheet, new Event("click"), document.createElement("button"));
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          "system.cardsLocked": true,
+        }),
+      );
+    });
+  });
 });

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -3,7 +3,7 @@ import { executeBankRoll, executeClientRoll } from "../rolls/roll-executor.js";
 import { MissionTrackerApp } from "../mission/MissionTrackerApp.js";
 import { handleActionError } from "../utils/ui-errors.js";
 import { activateTabs } from "../utils/sheet-tabs.js";
-import { enterDebtMode } from "./bankruptcy-handler.js";
+import { enterDebtMode, attemptLoanRepayment } from "./bankruptcy-handler.js";
 
 // HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
 export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
@@ -16,6 +16,9 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
       clientRoll: FranchiseSheet.onClientRoll,
       openMissionTracker: FranchiseSheet.onOpenMissionTracker,
       enterDebt: FranchiseSheet.onEnterDebt,
+      toggleDebtMode: FranchiseSheet.onToggleDebtMode,
+      toggleCardsLocked: FranchiseSheet.onToggleCardsLocked,
+      attemptRepayment: FranchiseSheet.onAttemptRepayment,
     },
   };
 
@@ -80,6 +83,73 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
     const shortfall = Math.abs(system.bank);
     void enterDebtMode(this.actor, shortfall).catch((err: unknown) => {
       handleActionError(err, "Debt mode entry failed", "INSPECTRES.ErrorEnterDebtModeFailed", "Failed to enter debt mode");
+    });
+  }
+
+  static async onToggleDebtMode(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable || !game.user?.isGM) return;
+    const system = this.actor.system as unknown as FranchiseData;
+    const updateData = {
+      "system.debtMode": !system.debtMode,
+    } as unknown as Parameters<typeof this.actor.update>[0];
+    await this.actor.update(updateData);
+  }
+
+  static async onToggleCardsLocked(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable || !game.user?.isGM) return;
+    const system = this.actor.system as unknown as FranchiseData;
+    const updateData = {
+      "system.cardsLocked": !system.cardsLocked,
+    } as unknown as Parameters<typeof this.actor.update>[0];
+    await this.actor.update(updateData);
+  }
+
+  static async onAttemptRepayment(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
+    const system = this.actor.system as unknown as FranchiseData;
+    if (!system.debtMode) {
+      ui.notifications?.warn(game.i18n?.localize("INSPECTRES.InfoNotInDebt") ?? "Franchise is not in debt.");
+      return;
+    }
+    // Ask GM for earned dice this mission
+    const earnedInput = await foundry.applications.api.DialogV2.wait({
+      window: { title: game.i18n?.localize("INSPECTRES.DialogRepaymentTitle") ?? "Loan Repayment" },
+      content: `
+        <form>
+          <div class="form-group">
+            <label for="earnedDice">${game.i18n?.localize("INSPECTRES.EarnedDiceThisMission") ?? "Earned Dice This Mission"}</label>
+            <input type="number" name="earnedDice" id="earnedDice" min="0" value="0" required />
+          </div>
+        </form>
+      `,
+      buttons: [
+        {
+          action: "repay",
+          label: game.i18n?.localize("INSPECTRES.ButtonAttemptRepayment") ?? "Attempt Repayment",
+          default: true,
+          callback: (_event, _button, dialog) => {
+            const form = dialog.querySelector("form") as HTMLFormElement;
+            const data = new FormData(form);
+            const earned = data.get("earnedDice");
+            return Math.max(0, Number(earned ?? 0));
+          },
+        },
+        {
+          action: "cancel",
+          label: game.i18n?.localize("INSPECTRES.Cancel") ?? "Cancel",
+        },
+      ],
+    });
+
+    if (earnedInput === null || earnedInput === "cancel" || typeof earnedInput !== "number") return;
+
+    void attemptLoanRepayment(this.actor, earnedInput).catch((err: unknown) => {
+      handleActionError(
+        err,
+        "Loan repayment failed",
+        "INSPECTRES.ErrorRepaymentFailed",
+        "Loan repayment failed",
+      );
     });
   }
 }

--- a/foundry/src/franchise/franchise-sheet.hbs
+++ b/foundry/src/franchise/franchise-sheet.hbs
@@ -156,6 +156,34 @@
             </label>
           {{/if}}
         </div>
+        {{#if isGm}}
+          <div class="debt-controls">
+            <p class="debt-controls-label">{{localize "INSPECTRES.GMDebtOverride"}}</p>
+            <button
+              type="button"
+              class="inspectres-button"
+              data-action="toggleDebtMode"
+            >
+              {{#if system.debtMode}}{{localize "INSPECTRES.ExitDebtMode"}}{{else}}{{localize "INSPECTRES.EnterDebtMode"}}{{/if}}
+            </button>
+            {{#if system.debtMode}}
+              <button
+                type="button"
+                class="inspectres-button"
+                data-action="toggleCardsLocked"
+              >
+                {{#if system.cardsLocked}}{{localize "INSPECTRES.UnlockCards"}}{{else}}{{localize "INSPECTRES.LockCards"}}{{/if}}
+              </button>
+              <button
+                type="button"
+                class="inspectres-button"
+                data-action="attemptRepayment"
+              >
+                {{localize "INSPECTRES.AttemptRepayment"}}
+              </button>
+            {{/if}}
+          </div>
+        {{/if}}
       </section>
 
     </div><!-- /notes tab -->

--- a/foundry/src/lang/en.json
+++ b/foundry/src/lang/en.json
@@ -249,6 +249,17 @@
     "ErrorAlreadyInDebt": "Franchise is already in debt.",
     "WarnCantEnterDebtWithPositiveBank": "Franchise must have zero or negative Bank to enter Debt Mode.",
     "SettingCurrentDay": "In-Game Day",
-    "SettingCurrentDayHint": "Current in-game day for recovery tracking. Agents recover based on this count."
+    "SettingCurrentDayHint": "Current in-game day for recovery tracking. Agents recover based on this count.",
+    "GMDebtOverride": "GM Controls",
+    "EnterDebtMode": "Enter Debt Mode",
+    "ExitDebtMode": "Exit Debt Mode",
+    "LockCards": "Lock Cards",
+    "UnlockCards": "Unlock Cards",
+    "AttemptRepayment": "Attempt Repayment",
+    "DialogRepaymentTitle": "Loan Repayment",
+    "EarnedDiceThisMission": "Earned Dice This Mission",
+    "ButtonAttemptRepayment": "Attempt Repayment",
+    "Cancel": "Cancel",
+    "ErrorRepaymentFailed": "Loan repayment failed"
   }
 }


### PR DESCRIPTION
## Summary

- Implement GM control UI for debt management (manual overrides for edge cases)
- Add dialog-based loan repayment with earned dice tracking
- Cards remain locked during debt mode; unlock only on successful repayment
- All acceptance criteria from composite #170 now satisfied

## Test Coverage

- 154 tests passing (4 new debt control tests added)
- Type checking clean
- Build successful

## Closes

- #17 — Bankruptcy Handler (Cards lock, loan UI, repayment)
- #170 — Sprint: Bankruptcy Handler (debt mechanics & repayment)