### PR TITLE
feat: Add GM control surfaces to Franchise sheet

### DIFF
--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -4,6 +4,7 @@ import { MissionTrackerApp } from "../mission/MissionTrackerApp.js";
 import { handleActionError } from "../utils/ui-errors.js";
 import { activateTabs } from "../utils/sheet-tabs.js";
 import { enterDebtMode, attemptLoanRepayment } from "./bankruptcy-handler.js";
+import { getSyncManager } from "../socket/socket-sync.js";
 
 // HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
 export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
@@ -19,6 +20,9 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
       toggleDebtMode: FranchiseSheet.onToggleDebtMode,
       toggleCardsLocked: FranchiseSheet.onToggleCardsLocked,
       attemptRepayment: FranchiseSheet.onAttemptRepayment,
+      advanceDay: FranchiseSheet.onAdvanceDay,
+      regressDay: FranchiseSheet.onRegressDay,
+      beginVacation: FranchiseSheet.onBeginVacation,
     },
   };
 
@@ -37,7 +41,8 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
     const system = this.actor.system as unknown as FranchiseData;
     const isGm = game.user?.isGM ?? false;
     const missionComplete = system.missionGoal > 0 && system.missionPool >= system.missionGoal;
-    return { ...base, system, isGm, missionComplete };
+    const currentDay = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number ?? 1;
+    return { ...base, system, isGm, missionComplete, currentDay };
   }
 
   static async onBankRoll(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
@@ -120,6 +125,131 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
     void attemptLoanRepayment(this.actor, earnedInput).catch((err: unknown) => {
       handleActionError(err, "Loan repayment failed", "INSPECTRES.ErrorRepaymentFailed", "Loan repayment failed");
     });
+  }
+
+  static async onAdvanceDay(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable || !(game.user?.isGM ?? false)) return;
+    const currentDay = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number ?? 1;
+    const nextDay = currentDay + 1;
+    void (game.settings as unknown as { set: (namespace: string, key: string, value: unknown) => Promise<unknown> })?.set("inspectres", "currentDay", nextDay).catch((err: unknown) => {
+      handleActionError(err, "Day advance failed", "INSPECTRES.ErrorDayAdvanceFailed", "Failed to advance day");
+    });
+  }
+
+  static async onRegressDay(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable || !(game.user?.isGM ?? false)) return;
+    const currentDay = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number ?? 1;
+    const prevDay = Math.max(1, currentDay - 1);
+    void (game.settings as unknown as { set: (namespace: string, key: string, value: unknown) => Promise<unknown> })?.set("inspectres", "currentDay", prevDay).catch((err: unknown) => {
+      handleActionError(err, "Day regress failed", "INSPECTRES.ErrorDayRegressFailed", "Failed to revert day");
+    });
+  }
+
+  static async onBeginVacation(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable || !(game.user?.isGM ?? false)) return;
+    const system = this.actor.system as unknown as FranchiseData;
+    if (system.missionPool === 0) {
+      ui.notifications?.warn(FranchiseSheet.localize("INSPECTRES.WarnNoMissionPool", "No mission pool to distribute."));
+      return;
+    }
+
+    const confirmed = await foundry.applications.api.DialogV2.confirm({
+      window: { title: FranchiseSheet.localize("INSPECTRES.ConfirmVacationTitle", "Begin Vacation") },
+      content: FranchiseSheet.localize("INSPECTRES.ConfirmVacationBody", "End mission and begin vacation? This will open the distribution dialog."),
+    });
+
+    if (!confirmed) return;
+
+    void FranchiseSheet.openDistributionDialog.call(this).catch((err: unknown) => {
+      handleActionError(err, "Distribution dialog failed", "INSPECTRES.ErrorUpdateFailed", "Failed to open distribution dialog");
+    });
+  }
+
+  private static async openDistributionDialog(this: FranchiseSheet): Promise<void> {
+    const system = this.actor.system as unknown as FranchiseData;
+    const total = system.missionPool;
+    const players = game.users?.filter((u) => u.active && !u.isGM) ?? [];
+
+    const playerInputs = players
+      .map((u) => `<label>${u.name ?? u.id}: <input type="number" name="player-${u.id}" min="0" value="0" /></label>`)
+      .join("\n");
+
+    const instruction = game.i18n?.format("INSPECTRES.DistributeDialogInstruction", { total: String(total) })
+      ?? `Assign ${total} franchise dice among players.`;
+
+    const content = `
+      <form class="inspectres-distribute-dialog">
+        <p>${instruction}</p>
+        ${playerInputs || "<p>No active players.</p>"}
+      </form>
+    `;
+
+    const result = await foundry.applications.api.DialogV2.wait({
+      window: { title: game.i18n?.localize("INSPECTRES.DistributeDialogTitle") ?? "Distribute Mission Dice" },
+      rejectClose: false,
+      content,
+      buttons: [
+        {
+          action: "confirm",
+          label: game.i18n?.localize("INSPECTRES.DistributeDialogConfirm") ?? "Confirm",
+          default: true,
+          callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
+            const form = dialog.querySelector("form") as HTMLFormElement | null;
+            if (!form) return null;
+            const data = new FormData(form);
+            const distribution: Record<string, number> = {};
+            for (const user of players) {
+              const raw = Number(data.get(`player-${user.id}`) ?? 0);
+              distribution[user.id] = isNaN(raw) ? 0 : Math.max(0, raw);
+            }
+            return distribution;
+          },
+        },
+        {
+          action: "cancel",
+          label: game.i18n?.localize("INSPECTRES.DistributeDialogCancel") ?? "Cancel",
+          callback: () => null,
+        },
+      ],
+    });
+
+    if (result === null || result === undefined) return;
+    const distribution = result as Record<string, number>;
+
+    const refreshedSystem = this.actor.system as unknown as FranchiseData;
+    const refreshedTotal = refreshedSystem.missionPool;
+    const distributedTotal = Object.values(distribution).reduce((sum, v) => sum + v, 0);
+
+    if (distributedTotal !== refreshedTotal) {
+      const msg = game.i18n?.format("INSPECTRES.DistributeDialogTotalMismatch", { total: String(refreshedTotal) })
+        ?? `Total must equal ${refreshedTotal} dice.`;
+      ui.notifications?.warn(msg);
+      return;
+    }
+
+    const updateData = { "system.missionPool": 0, "system.missionGoal": 0, "system.missionStartDay": 0 } as unknown as Parameters<typeof this.actor.update>[0];
+    await this.actor.update(updateData);
+
+    const syncManager = getSyncManager();
+    const event: Parameters<typeof syncManager.queueEvent>[0] = {
+      type: "mission-update",
+      data: { missionPool: 0, missionGoal: 0, missionStartDay: 0 },
+      senderId: game.user?.id ?? "unknown",
+      timestamp: Date.now(),
+    };
+    syncManager.queueEvent(event);
+
+    const lines = Object.entries(distribution)
+      .filter(([, v]) => v > 0)
+      .map(([userId, count]) => {
+        const user = game.users?.get(userId);
+        const name = user?.name ?? userId;
+        return `${name}: ${count} ${count === 1 ? (game.i18n?.localize("INSPECTRES.DieSingular") ?? "die") : (game.i18n?.localize("INSPECTRES.DiePlural") ?? "dice")}`;
+      });
+
+    const baseMsg = game.i18n?.localize("INSPECTRES.MissionCompleteAnnounce") ?? "The mission is complete! Franchise dice have been distributed.";
+    const content2 = `<p>${baseMsg}</p><ul>${lines.map((l) => `<li>${l}</li>`).join("")}</ul>`;
+    await ChatMessage.create({ content: content2 } as unknown as Parameters<typeof ChatMessage.create>[0]);
   }
 
   private static localize(key: string, fallback: string): string {

--- a/foundry/src/franchise/franchise-sheet.hbs
+++ b/foundry/src/franchise/franchise-sheet.hbs
@@ -85,6 +85,20 @@
         </div>
       </section>
 
+      <!-- Day Display Section (GM only) -->
+      {{#if isGm}}
+        <section class="inspectres-section">
+          <h2>{{localize "INSPECTRES.InGameDay"}}</h2>
+          <div class="day-row">
+            <span class="day-display">Day {{currentDay}}</span>
+            <div class="day-controls">
+              <button type="button" class="inspectres-button" data-action="regressDay" title="Previous day">−</button>
+              <button type="button" class="inspectres-button" data-action="advanceDay" title="Next day">+</button>
+            </div>
+          </div>
+        </section>
+      {{/if}}
+
       <!-- Mission Section -->
       <section class="inspectres-section">
         <h2>{{localize "INSPECTRES.Mission"}}</h2>
@@ -104,9 +118,16 @@
             <div class="inspectres-progress-fill" style="width: {{inspectres-multiply (inspectres-divide system.missionPool (inspectres-max system.missionGoal 1)) 100}}%"></div>
           </div>
         </div>
-        <button type="button" class="inspectres-roll-button" data-action="openMissionTracker">
-          {{localize "INSPECTRES.OpenMissionTracker"}}
-        </button>
+        <div class="mission-controls">
+          <button type="button" class="inspectres-roll-button" data-action="openMissionTracker">
+            {{localize "INSPECTRES.OpenMissionTracker"}}
+          </button>
+          {{#if isGm}}
+            <button type="button" class="inspectres-roll-button" data-action="beginVacation" {{#if (eq system.missionPool 0)}}disabled{{/if}}>
+              {{localize "INSPECTRES.BeginVacation"}}
+            </button>
+          {{/if}}
+        </div>
       </section>
 
       <!-- Client Roll Section -->

--- a/foundry/src/lang/en.json
+++ b/foundry/src/lang/en.json
@@ -276,6 +276,13 @@
     "EarnedDiceThisMission": "Earned Dice This Mission",
     "ButtonAttemptRepayment": "Attempt Repayment",
     "Cancel": "Cancel",
-    "ErrorRepaymentFailed": "Loan repayment failed"
+    "ErrorRepaymentFailed": "Loan repayment failed",
+    "InGameDay": "In-Game Day",
+    "BeginVacation": "Begin Vacation",
+    "ConfirmVacationTitle": "Begin Vacation",
+    "ConfirmVacationBody": "End mission and begin vacation? This will open the distribution dialog.",
+    "WarnNoMissionPool": "No mission pool to distribute.",
+    "ErrorDayAdvanceFailed": "Failed to advance day",
+    "ErrorDayRegressFailed": "Failed to revert day"
   }
 }

--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -846,3 +846,47 @@
 .application:has(form.dialog-form) {
   height: auto !important;
 }
+
+/* ─── Franchise sheet day controls ──────────────────────────────────────── */
+
+.inspectres-franchise-sheet {
+  .day-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .day-display {
+    font-size: 1.1rem;
+    font-weight: 600;
+    flex: 1;
+    padding: 0.5rem;
+    background: var(--inspectres-section-bg);
+    border: 1px solid var(--inspectres-input-border);
+    border-radius: var(--inspectres-radius);
+  }
+
+  .day-controls {
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .day-controls button {
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+
+  .mission-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    button {
+      flex: 1;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements composite issue #182: three focused GM control additions to the Franchise sheet.

- **Day counter + buttons** (#162): Visible in-game day display with +/- buttons to advance/revert day
- **Vacation trigger** (#166): Direct "Begin Vacation" button that opens the distribution dialog from Franchise sheet
- **Mission state cleanup**: Resets missionPool, missionGoal, and missionStartDay on vacation completion

## Implementation
- Added day display section (GM-only) to Stats tab with advance/regress day actions
- Added "Begin Vacation" button to Mission section
- Vacation button opens the distribution dialog (copied from MissionTrackerApp)
- On distribution completion, clears mission state and sends socket sync event to all players
- All controls GM-only with proper permission gating

## Test Plan
- [x] Type checker passes (no TypeScript errors)
- [x] Tests pass (183 tests, all green)
- [x] Build succeeds with no errors
- [x] All acceptance criteria from composite #182 met:
  - [x] Day counter visible with +/- buttons
  - [x] Day advance triggers socket notification
  - [x] Vacation button accessible and opens distribution dialog
  - [x] Mission state resets after vacation completion
  - [x] No regressions in existing Franchise sheet functionality
  - [x] All controls work in editable mode, properly gated to GM

## Files Changed
- `FranchiseSheet.ts`: Added day advance/regress/vacation handlers
- `franchise-sheet.hbs`: Added day display section and vacation button
- `en.json`: Added 6 new localization keys
- `inspectres.css`: Added styles for day controls and mission controls layout

Closes #182
Closes #162
Closes #165
Closes #166