### PR TITLE
feat: Add GM day controls and mission timeline tracking

### DIFF
--- a/docs/current/components/franchise-sheet.md
+++ b/docs/current/components/franchise-sheet.md
@@ -83,6 +83,33 @@ If the franchise fails, the campaign ends or resets. This is an ending state, no
 > - Franchise stress mounting (at halfway point to crisis)
 > - Next mission will be harder if stress isn't managed
 
+## GM Controls: Time Progression
+
+### Advancing the Calendar
+
+The **Franchise Sheet** includes day advancement controls in the top right:
+- **+1 Day** button — Advance the calendar by one day
+- **-1 Day** button — Regress to the previous day (if needed)
+- **Current Day** display — Shows the current day number (starts at 1)
+
+**Why use this?** InSpectres tracking uses wall-clock days, not game time. When a mission ends and agents go on vacation or recovery, advancing the day tracks the real passage of time. The system automatically:
+1. Clears any agents who finished recovery (their recovery period expires based on the day they started)
+2. Updates the Mission Tracker to show how many days have passed since the current mission started
+
+### Mission Timeline
+
+When you start a new mission:
+1. **Open the Mission Tracker** (button on Franchise Sheet)
+2. **Advance the day** when a mission ends or agents take vacation
+3. **Watch elapsed days** in the Mission Tracker — shows how long the current mission has been running
+
+The Mission Tracker displays:
+- **Mission Pool** — Dice agents have earned so far
+- **Goal** — Dice needed to complete the mission
+- **Elapsed Days** — Days since mission started (automatically calculated)
+
+When elapsed days reach your intended mission length, that's your cue to wrap up and move toward completion.
+
 ## Tips
 
 - **Track stress carefully** — It's a real threat. Failed missions compound it

--- a/foundry/src/agent/recovery-utils.ts
+++ b/foundry/src/agent/recovery-utils.ts
@@ -78,11 +78,19 @@ export function computeRecoveryStatus(
   };
 }
 
-export async function autoClearRecoveredAgents(currentDay: number): Promise<void> {
-  if (typeof game === "undefined" || !game.actors) return;
-  if (!game.user?.isGM) return;
+export interface AutoClearResult {
+  cleared: number;
+  failed: number;
+  errors: Array<{ agentName: string; error: string }>;
+}
 
-  const updates: Array<{ id: string; changes: Record<string, number> }> = [];
+export async function autoClearRecoveredAgents(currentDay: number): Promise<AutoClearResult> {
+  const result: AutoClearResult = { cleared: 0, failed: 0, errors: [] };
+
+  if (typeof game === "undefined" || !game.actors) return result;
+  if (!game.user?.isGM) return result;
+
+  const updates: Array<{ id: string; name: string; changes: Record<string, number> }> = [];
 
   for (const actor of game.actors) {
     if ((actor.type as string) !== "agent") continue;
@@ -95,18 +103,32 @@ export async function autoClearRecoveredAgents(currentDay: number): Promise<void
     if (daysElapsed >= system.daysOutOfAction) {
       updates.push({
         id: actor.id ?? "",
+        name: actor.name ?? "Unknown",
         changes: { "system.daysOutOfAction": 0, "system.recoveryStartedAt": 0 },
       });
     }
   }
 
-  if (updates.length === 0) return;
+  if (updates.length === 0) return result;
 
-  // Batch update all recovered agents in one call
-  for (const { id, changes } of updates) {
+  // Update all recovered agents, tracking success/failure
+  for (const { id, name, changes } of updates) {
     const actor = game.actors?.get(id);
-    if (actor) {
+    if (!actor) {
+      result.failed += 1;
+      result.errors.push({ agentName: name, error: "Actor not found" });
+      continue;
+    }
+
+    try {
       await actor.update(changes);
+      result.cleared += 1;
+    } catch (err: unknown) {
+      result.failed += 1;
+      const message = err instanceof Error ? err.message : String(err);
+      result.errors.push({ agentName: name, error: message });
     }
   }
+
+  return result;
 }

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -5,6 +5,7 @@ import { handleActionError } from "../utils/ui-errors.js";
 import { activateTabs } from "../utils/sheet-tabs.js";
 import { enterDebtMode, attemptLoanRepayment } from "./bankruptcy-handler.js";
 import { getSyncManager } from "../socket/socket-sync.js";
+import { getCurrentDaySetting, setCurrentDaySetting } from "../utils/settings-utils.js";
 
 // HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
 export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
@@ -41,7 +42,7 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
     const system = this.actor.system as unknown as FranchiseData;
     const isGm = game.user?.isGM ?? false;
     const missionComplete = system.missionGoal > 0 && system.missionPool >= system.missionGoal;
-    const currentDay = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number ?? 1;
+    const currentDay = getCurrentDaySetting();
     return { ...base, system, isGm, missionComplete, currentDay };
   }
 
@@ -129,18 +130,18 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
 
   static async onAdvanceDay(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
     if (!this.isEditable || !(game.user?.isGM ?? false)) return;
-    const currentDay = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number ?? 1;
+    const currentDay = getCurrentDaySetting();
     const nextDay = currentDay + 1;
-    void (game.settings as unknown as { set: (namespace: string, key: string, value: unknown) => Promise<unknown> })?.set("inspectres", "currentDay", nextDay).catch((err: unknown) => {
+    void setCurrentDaySetting(nextDay).catch((err: unknown) => {
       handleActionError(err, "Day advance failed", "INSPECTRES.ErrorDayAdvanceFailed", "Failed to advance day");
     });
   }
 
   static async onRegressDay(this: FranchiseSheet, _event: Event, _target: HTMLElement): Promise<void> {
     if (!this.isEditable || !(game.user?.isGM ?? false)) return;
-    const currentDay = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number ?? 1;
+    const currentDay = getCurrentDaySetting();
     const prevDay = Math.max(1, currentDay - 1);
-    void (game.settings as unknown as { set: (namespace: string, key: string, value: unknown) => Promise<unknown> })?.set("inspectres", "currentDay", prevDay).catch((err: unknown) => {
+    void setCurrentDaySetting(prevDay).catch((err: unknown) => {
       handleActionError(err, "Day regress failed", "INSPECTRES.ErrorDayRegressFailed", "Failed to revert day");
     });
   }

--- a/foundry/src/franchise/InSpectresFranchise.ts
+++ b/foundry/src/franchise/InSpectresFranchise.ts
@@ -4,6 +4,7 @@
  */
 
 import type { FranchiseData } from "./franchise-schema.js";
+import { getCurrentDaySetting } from "../utils/settings-utils.js";
 
 /**
  * Add franchise dice to an actor's mission pool
@@ -42,5 +43,27 @@ export class InSpectresFranchise extends Actor {
    */
   async awardMissionDice(amount: number): Promise<void> {
     return addToMissionPool(this, amount);
+  }
+
+  /**
+   * Set missionStartDay when mission goal transitions from 0 to > 0
+   */
+  override _onUpdate(changed: unknown, options: unknown, userId: unknown): void {
+    super._onUpdate(changed as never, options as never, userId as never);
+    if (typeof changed !== "object" || changed === null) return;
+    const systemChanged = (changed as Record<string, unknown>)["system"] as Record<string, unknown> | undefined;
+    if (!systemChanged) return;
+
+    const newGoal = systemChanged["missionGoal"] as number | undefined;
+    if (typeof newGoal !== "number" || newGoal <= 0) return;
+
+    const system = this.system as unknown as FranchiseData;
+    if (system.missionGoal > 0) return; // Mission already started
+
+    const currentDay = getCurrentDaySetting();
+    void this.update({ "system.missionStartDay": currentDay } as Parameters<typeof this.update>[0]).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[INSPECTRES] Failed to set mission start day:", { currentDay, error: message });
+    });
   }
 }

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -14,6 +14,15 @@ import { MissionTrackerApp } from "./mission/MissionTrackerApp.js";
 import { onMissionSocketEvent } from "./mission/socket.js";
 import { handleActionError } from "./utils/ui-errors.js";
 import { autoClearRecoveredAgents } from "./agent/recovery-utils.js";
+import { getCurrentDaySetting } from "./utils/settings-utils.js";
+
+// Helper to re-render Mission Tracker with error handling
+function rerenderMissionTracker(context: string): void {
+  if (!MissionTrackerApp.instance) return;
+  void MissionTrackerApp.instance.render().catch((err: unknown) => {
+    handleActionError(err, `Mission tracker re-render failed (${context})`, "INSPECTRES.ErrorMissionTrackerOpen", "Mission Tracker failed to update");
+  });
+}
 
 Hooks.once("init", async function () {
   try {
@@ -70,13 +79,15 @@ Hooks.once("init", async function () {
       }
       void (async () => {
         try {
-          await autoClearRecoveredAgents(newDay);
-          // Re-render mission tracker to show updated elapsed days
-          if (MissionTrackerApp.instance) {
-            await MissionTrackerApp.instance.render().catch((err: unknown) => {
-              handleActionError(err, "Mission tracker re-render failed (day change)", "INSPECTRES.ErrorMissionTrackerOpen", "Mission Tracker failed to update");
-            });
+          const result = await autoClearRecoveredAgents(newDay);
+          if (result.failed > 0) {
+            console.warn("[INSPECTRES] Some agents failed to auto-clear recovery:", result);
+            if (ui.notifications) {
+              ui.notifications.warn(game.i18n?.localize("INSPECTRES.ErrorPartialRecoveryFailed") ?? "Some agents failed to clear recovery state");
+            }
           }
+          // Re-render mission tracker to show updated elapsed days
+          rerenderMissionTracker("day change");
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           console.error("[INSPECTRES] Auto-clear recovered agents failed:", { newDay, error: err, errorMessage: message });
@@ -113,18 +124,12 @@ Hooks.once("init", async function () {
 
 Hooks.once("ready", function () {
   onMissionSocketEvent(() => {
-    if (MissionTrackerApp.instance) {
-      void MissionTrackerApp.instance.render().catch((err: unknown) => {
-        handleActionError(err, "Mission tracker re-render failed (socket event)", "INSPECTRES.ErrorMissionTrackerOpen", "Mission Tracker failed to update");
-      });
-    }
+    rerenderMissionTracker("socket event");
   });
 });
 
 Hooks.on("updateActor", function (actor: Actor) {
-  if ((actor.type as string) === "franchise" && MissionTrackerApp.instance) {
-    void MissionTrackerApp.instance.render().catch((err: unknown) => {
-      handleActionError(err, "Mission tracker re-render failed (actor update)", "INSPECTRES.ErrorMissionTrackerOpen", "Mission Tracker failed to update");
-    });
+  if ((actor.type as string) === "franchise") {
+    rerenderMissionTracker("actor update");
   }
 });

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -71,6 +71,12 @@ Hooks.once("init", async function () {
       void (async () => {
         try {
           await autoClearRecoveredAgents(newDay);
+          // Re-render mission tracker to show updated elapsed days
+          if (MissionTrackerApp.instance) {
+            await MissionTrackerApp.instance.render().catch((err: unknown) => {
+              handleActionError(err, "Mission tracker re-render failed (day change)", "INSPECTRES.ErrorMissionTrackerOpen", "Mission Tracker failed to update");
+            });
+          }
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           console.error("[INSPECTRES] Auto-clear recovered agents failed:", { newDay, error: err, errorMessage: message });

--- a/foundry/src/lang/en.json
+++ b/foundry/src/lang/en.json
@@ -60,6 +60,7 @@
     "MissionTrackerTitle": "Mission Tracker",
     "MissionTrackerPool": "Mission Dice Earned",
     "MissionTrackerGoal": "Goal",
+    "MissionTrackerElapsed": "Elapsed Days",
     "MissionTrackerComplete": "Mission complete!",
     "MissionTrackerBeginCleanUp": "Begin Clean Up",
     "MissionTrackerEndEarly": "End Mission Early",

--- a/foundry/src/mission/MissionTrackerApp.test.ts
+++ b/foundry/src/mission/MissionTrackerApp.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("MissionTrackerApp day arithmetic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("elapsed days calculation", () => {
+    it("calculates zero elapsed when mission starts today", () => {
+      const currentDay = 10;
+      const missionStartDay = 10;
+      const elapsedDays = Math.max(0, currentDay - missionStartDay);
+      expect(elapsedDays).toBe(0);
+    });
+
+    it("calculates correct elapsed when mission started yesterday", () => {
+      const currentDay = 10;
+      const missionStartDay = 9;
+      const elapsedDays = Math.max(0, currentDay - missionStartDay);
+      expect(elapsedDays).toBe(1);
+    });
+
+    it("calculates correct elapsed when mission started multiple days ago", () => {
+      const currentDay = 15;
+      const missionStartDay = 10;
+      const elapsedDays = Math.max(0, currentDay - missionStartDay);
+      expect(elapsedDays).toBe(5);
+    });
+
+    it("clamps to zero when currentDay is before start", () => {
+      const currentDay = 5;
+      const missionStartDay = 10;
+      const elapsedDays = Math.max(0, currentDay - missionStartDay);
+      expect(elapsedDays).toBe(0);
+    });
+
+    it("handles day 1 correctly", () => {
+      const currentDay = 1;
+      const missionStartDay = 1;
+      const elapsedDays = Math.max(0, currentDay - missionStartDay);
+      expect(elapsedDays).toBe(0);
+    });
+
+    it("handles large day numbers", () => {
+      const currentDay = 365;
+      const missionStartDay = 1;
+      const elapsedDays = Math.max(0, currentDay - missionStartDay);
+      expect(elapsedDays).toBe(364);
+    });
+  });
+});

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -1,6 +1,7 @@
 import { findFranchiseActor, franchiseSystemData } from "../franchise/franchise-utils.js";
 import { handleActionError } from "../utils/ui-errors.js";
 import { getSyncManager, type MissionState } from "../socket/socket-sync.js";
+import { getCurrentDaySetting } from "../utils/settings-utils.js";
 
 export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
   static instance: MissionTrackerApp | null = null;
@@ -44,7 +45,7 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
     const progressPercent = missionGoal > 0 ? Math.min(100, Math.round((missionPool / missionGoal) * 100)) : 0;
     const missionComplete = missionGoal > 0 && missionPool >= missionGoal;
 
-    const currentDay = ((game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number | undefined) ?? 1;
+    const currentDay = getCurrentDaySetting();
     const missionStartDay = system.missionStartDay ?? currentDay;
     const elapsedDays = Math.max(0, currentDay - missionStartDay);
 

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -36,14 +36,19 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
   override async _prepareContext(_options: foundry.applications.api.ApplicationV2Options): Promise<Record<string, unknown>> {
     const franchise = findFranchiseActor();
     if (!franchise) {
-      return { missionPool: 0, missionGoal: 0, progressPercent: 0, missionComplete: false, isGm: game.user?.isGM ?? false };
+      return { missionPool: 0, missionGoal: 0, progressPercent: 0, missionComplete: false, isGm: game.user?.isGM ?? false, elapsedDays: 0 };
     }
     const system = franchiseSystemData(franchise);
     const missionPool = system.missionPool;
     const missionGoal = system.missionGoal;
     const progressPercent = missionGoal > 0 ? Math.min(100, Math.round((missionPool / missionGoal) * 100)) : 0;
     const missionComplete = missionGoal > 0 && missionPool >= missionGoal;
-    return { missionPool, missionGoal, progressPercent, missionComplete, isGm: game.user?.isGM ?? false };
+
+    const currentDay = ((game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get("inspectres", "currentDay") as number | undefined) ?? 1;
+    const missionStartDay = system.missionStartDay ?? currentDay;
+    const elapsedDays = Math.max(0, currentDay - missionStartDay);
+
+    return { missionPool, missionGoal, progressPercent, missionComplete, isGm: game.user?.isGM ?? false, elapsedDays };
   }
 
   static async onBeginCleanUp(this: MissionTrackerApp, _event: Event, _target: HTMLElement): Promise<void> {

--- a/foundry/src/mission/mission-tracker.hbs
+++ b/foundry/src/mission/mission-tracker.hbs
@@ -7,6 +7,7 @@
     <div class="tracker-stats">
       <span>{{localize "INSPECTRES.MissionTrackerPool"}}: {{missionPool}}</span>
       <span>{{localize "INSPECTRES.MissionTrackerGoal"}}: {{missionGoal}}</span>
+      <span>{{localize "INSPECTRES.MissionTrackerElapsed"}}: {{elapsedDays}}</span>
     </div>
     <div class="inspectres-progress-bar">
       <div

--- a/foundry/src/utils/settings-utils.ts
+++ b/foundry/src/utils/settings-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Utility functions for accessing Foundry game settings with proper typing
+ */
+
+export function getCurrentDaySetting(): number {
+  const value = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get(
+    "inspectres",
+    "currentDay",
+  ) as number | undefined;
+  return value ?? 1;
+}
+
+export async function setCurrentDaySetting(day: number): Promise<unknown> {
+  return (game.settings as unknown as { set: (namespace: string, key: string, value: unknown) => Promise<unknown> })?.set(
+    "inspectres",
+    "currentDay",
+    day,
+  );
+}


### PR DESCRIPTION
## Summary

Implements GM day control surfaces on the Franchise Sheet, completing issue #191:

- **Elapsed days display** in Mission Tracker showing mission duration
- **Day advancement buttons** (+1 Day, -1 Day) for timeline progression
- **Auto-set mission start day** when mission goal transitions from 0 to >0
- **Improved error handling** for recovery auto-clear with detailed failure reporting
- **Refactored settings access** with reusable helpers to eliminate duplicate casting code
- **Consolidated Mission Tracker rendering** to reduce code duplication

## Technical Changes

**New files:**
- `foundry/src/utils/settings-utils.ts` — Centralized typed access to currentDay setting

**Modified:**
- `InSpectresFranchise._onUpdate()` — Detects mission start and auto-sets missionStartDay
- `autoClearRecoveredAgents()` — Returns result object with cleared/failed counts and errors
- `MissionTrackerApp._prepareContext()` — Calculates and displays elapsed days
- `FranchiseSheet` — Day advancement controls (+1, -1) with GM-only guards
- `init.ts` — Extracted Mission Tracker rendering helper, consolidated onChange callback
- `en.json` — Added localization for elapsed days display

**Tests:**
- Unit tests for elapsed days arithmetic (handles edge cases: day 1, large day numbers, negative elapsed)

## Addresses

- Mission tracker now shows how many days mission has been running
- GMs have fast, discoverable controls for day advancement (no settings navigation required)
- Mission start day automatically tracked when mission begins
- Recovery auto-clear errors properly reported instead of silently swallowed

Closes #191
Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>