### PR TITLE
feat: Agent recovery & death state management UI (fixes #164, #167, #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-04-25
-
 ### Added
 
 - **Weird Agent System**: New paranormal investigator archetypes with supernatural powers and special mechanics.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Semantic Versioning.
 
 ### Version Locations
 
-**Current version: `0.3.0`**
+**Current version: `0.2.0`**
 
 When bumping version, update **ALL** of these locations to keep them in sync:
 
@@ -88,7 +88,7 @@ When bumping version, update **ALL** of these locations to keep them in sync:
 4. **`CHANGELOG.md`** — **ONLY** during actual release (see below)
 5. **`docs/current/sidebar.json`** — if version-pinned docs exist (rare; confirm before adding)
 
-Use grep to verify sync: `grep -n "0.3.0" foundry/system.json foundry/package.json CHANGELOG.md docs/current/sidebar.json`
+Use grep to verify sync: `grep -n "0.2.0" foundry/system.json foundry/package.json CHANGELOG.md docs/current/sidebar.json`
 
 ### CHANGELOG.md Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,13 +78,17 @@ Semantic Versioning.
 
 ### Version Locations
 
+**Current version: `0.3.0`**
+
 When bumping version, update **ALL** of these locations to keep them in sync:
 
 1. **`foundry/system.json`** — `version` field (authoritative source)
-2. **`CHANGELOG.md`** — **ONLY** during actual release (see below)
-3. **`docs/current/sidebar.json`** — if version-pinned docs exist (rare; confirm before adding)
+2. **`package.json`** — `version` field (foundry/ directory)
+3. **`package-lock.json`** — auto-generated, commit after `npm install`
+4. **`CHANGELOG.md`** — **ONLY** during actual release (see below)
+5. **`docs/current/sidebar.json`** — if version-pinned docs exist (rare; confirm before adding)
 
-Use grep to verify sync: `grep -n "1.2.3" foundry/system.json CHANGELOG.md docs/current/sidebar.json`
+Use grep to verify sync: `grep -n "0.3.0" foundry/system.json foundry/package.json CHANGELOG.md docs/current/sidebar.json`
 
 ### CHANGELOG.md Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Where `$CHILD_ID` from `gh issue view $NUMBER --json id --jq .id`.
 
 ## Versioning
 
-Semantic Versioning. Version in `foundry/system.json`.
+Semantic Versioning.
 
 | Change | Version |
 |--------|---------|
@@ -76,10 +76,38 @@ Semantic Versioning. Version in `foundry/system.json`.
 | New functionality | MINOR |
 | Bug fixes, refactors, docs, CI | PATCH |
 
-**Changelog updates:**
-- Every PR with user-facing changes → add to `[Unreleased]` in `CHANGELOG.md`
-- Pure tooling/CI/docs → no entry required (unless user-visible)
-- Release → move `[Unreleased]` to dated section, bump version
+### Version Locations
+
+When bumping version, update **ALL** of these locations to keep them in sync:
+
+1. **`foundry/system.json`** — `version` field (authoritative source)
+2. **`CHANGELOG.md`** — **ONLY** during actual release (see below)
+3. **`docs/current/sidebar.json`** — if version-pinned docs exist (rare; confirm before adding)
+
+Use grep to verify sync: `grep -n "1.2.3" foundry/system.json CHANGELOG.md docs/current/sidebar.json`
+
+### CHANGELOG.md Rules
+
+**CRITICAL:** Never add a specific version number to CHANGELOG.md until **the release is triggered**. Follow this workflow:
+
+**During development (PRs and regular work):**
+- Add entry to `[Unreleased]` section only
+- Describe what changed in human-readable terms
+- Example:
+  ```markdown
+  ## [Unreleased]
+  - Add recovery UI controls to agent sheet
+  - Fix recovery timer calculation
+  - Improve debt mode styling
+  ```
+
+**At release time (tag + publish):**
+1. Move `[Unreleased]` section to new dated section: `## [1.2.3] - 2026-04-25`
+2. Bump version in `foundry/system.json` to match
+3. Create release commit + tag
+4. Publish
+
+This prevents: version creep in development, mismatched version numbers between code and changelog, and confusion about which version is actually released.
 
 Use `/changelog` skill for guidance.
 

--- a/foundry/package-lock.json
+++ b/foundry/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inspectres-vtt",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inspectres-vtt",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@foundryvtt/foundryvtt-cli": "^3.0.3",
         "@types/node": "^24.12.2",
@@ -17,6 +17,9 @@
         "typescript": "^5.7.2",
         "vite": "^8.0.8",
         "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/foundry/package.json
+++ b/foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inspectres-vtt",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "InSpectres paranormal investigation RPG system for Foundry VTT",
   "type": "module",
   "scripts": {

--- a/foundry/src/agent/AgentSheet.test.ts
+++ b/foundry/src/agent/AgentSheet.test.ts
@@ -465,4 +465,104 @@ describe("AgentSheet", () => {
     });
   });
 
+  describe("recovery management handlers", () => {
+    it("onReviveAgent clears death state", async () => {
+      const mockActor = new MockActorSheetV2().actor;
+      const sheet = Object.create(AgentSheet.prototype);
+      sheet.actor = mockActor;
+      sheet.isEditable = true;
+
+      const updateSpy = vi.spyOn(sheet.actor, "update").mockResolvedValue(sheet.actor);
+      const target = document.createElement("button");
+      target.setAttribute("data-action", "reviveAgent");
+
+      await AgentSheet.onReviveAgent.call(sheet, new Event("click"), target);
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          "system.isDead": false,
+          "system.daysOutOfAction": 0,
+          "system.recoveryStartedAt": 0,
+        })
+      );
+    });
+
+    it("onEmergencyRecovery opens dialog and sets recovery fields", async () => {
+      const mockActor = new MockActorSheetV2().actor;
+      const sheet = Object.create(AgentSheet.prototype);
+      sheet.actor = mockActor;
+      sheet.isEditable = true;
+
+      const updateSpy = vi.spyOn(sheet.actor, "update").mockResolvedValue(sheet.actor);
+
+      const mockDialogWait = vi.fn().mockResolvedValue({ days: 2 });
+      global.foundry = {
+        applications: {
+          api: {
+            DialogV2: { wait: mockDialogWait },
+          },
+        },
+      } as unknown as typeof foundry;
+
+      const target = document.createElement("button");
+      target.setAttribute("data-action", "emergencyRecovery");
+
+      await AgentSheet.onEmergencyRecovery.call(sheet, new Event("click"), target);
+
+      expect(mockDialogWait).toHaveBeenCalled();
+      expect(updateSpy).toHaveBeenCalled();
+    });
+
+    it("onOverrideRecoveryDay updates recovery end day", async () => {
+      const mockActor = new MockActorSheetV2().actor;
+      const sheet = Object.create(AgentSheet.prototype);
+      sheet.actor = mockActor;
+      sheet.isEditable = true;
+
+      const agentData: AgentData = {
+        description: "",
+        skills: { academics: { base: 1, penalty: 0 }, athletics: { base: 1, penalty: 0 }, technology: { base: 1, penalty: 0 }, contact: { base: 1, penalty: 0 } },
+        talent: "",
+        cool: 0,
+        isWeird: false,
+        characteristics: [],
+        missionPool: 0,
+        isDead: false,
+        daysOutOfAction: 3,
+        recoveryStartedAt: 5,
+        stress: 0,
+      };
+      Object.defineProperty(sheet.actor, "system", { value: agentData });
+
+      const updateSpy = vi.spyOn(sheet.actor, "update").mockResolvedValue(sheet.actor);
+
+      const input = document.createElement("input");
+      input.type = "number";
+      input.value = "10";
+      input.setAttribute("data-action", "overrideRecoveryDay");
+
+      await AgentSheet.onOverrideRecoveryDay.call(sheet, new Event("change"), input);
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          "system.daysOutOfAction": 5,
+        })
+      );
+    });
+
+    it("does not perform recovery actions when sheet is not editable", async () => {
+      const mockActor = new MockActorSheetV2().actor;
+      const sheet = Object.create(AgentSheet.prototype);
+      sheet.actor = mockActor;
+      sheet.isEditable = false;
+
+      const updateSpy = vi.spyOn(sheet.actor, "update").mockResolvedValue(sheet.actor);
+
+      await AgentSheet.onReviveAgent.call(sheet, new Event("click"), document.createElement("button"));
+      await AgentSheet.onEmergencyRecovery.call(sheet, new Event("click"), document.createElement("button"));
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -92,6 +92,9 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
       addCharacteristic: AgentSheet.onAddCharacteristic,
       removeCharacteristic: AgentSheet.onRemoveCharacteristic,
       editPortrait: AgentSheet.onEditPortrait,
+      reviveAgent: AgentSheet.onReviveAgent,
+      emergencyRecovery: AgentSheet.onEmergencyRecovery,
+      overrideRecoveryDay: AgentSheet.onOverrideRecoveryDay,
     },
   };
 
@@ -402,6 +405,97 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
       );
     } catch (err: unknown) {
       handleActionError(err, "Power activation failed", "INSPECTRES.ErrorPowerActivationFailed", "Failed to activate power");
+    }
+  }
+
+  static async onReviveAgent(this: AgentSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
+    try {
+      const updateData = {
+        "system.isDead": false,
+        "system.daysOutOfAction": 0,
+        "system.recoveryStartedAt": 0,
+      } as unknown as Parameters<typeof this.actor.update>[0];
+      await this.actor.update(updateData);
+      ui.notifications?.info(
+        game.i18n?.format("INSPECTRES.InfoAgentRevived", { actor: this.actor.name }) ?? `${this.actor.name} has been revived`,
+      );
+    } catch (err: unknown) {
+      handleActionError(err, "Failed to revive agent", "INSPECTRES.ErrorReviveFailed", "Could not update agent status");
+    }
+  }
+
+  static async onEmergencyRecovery(this: AgentSheet, _event: Event, _target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
+    const i18n = game.i18n;
+    const result = await foundry.applications.api.DialogV2.wait({
+      window: { title: i18n?.localize("INSPECTRES.EmergencyRecovery") ?? "Emergency Recovery" },
+      rejectClose: false,
+      content: `
+        <form class="inspectres-recovery-dialog">
+          <label>${i18n?.localize("INSPECTRES.DaysOutOfAction") ?? "Days out of action"}: <input type="number" name="days" min="1" max="10" value="2"></label>
+        </form>
+      `,
+      buttons: [
+        {
+          action: "set",
+          label: i18n?.localize("INSPECTRES.DialogSet") ?? "Set",
+          default: true,
+          callback: (_event: Event, _button: HTMLButtonElement, dialog: HTMLDialogElement) => {
+            const form = dialog.querySelector("form") as HTMLFormElement | null;
+            if (!form) return null;
+            const days = Math.max(1, Math.min(10, Number(new FormData(form).get("days") ?? 2)));
+            return { days: isNaN(days) ? 2 : days };
+          },
+        },
+        { action: "cancel", label: i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel" },
+      ],
+    });
+
+    if (result === null || result === undefined || result === "cancel") return;
+    const config = result as { days: number };
+    const currentDay = getCurrentDay();
+
+    try {
+      const updateData = {
+        "system.isDead": false,
+        "system.daysOutOfAction": config.days,
+        "system.recoveryStartedAt": currentDay,
+      } as unknown as Parameters<typeof this.actor.update>[0];
+      await this.actor.update(updateData);
+      ui.notifications?.info(
+        game.i18n?.format("INSPECTRES.InfoRecoveryStarted", { actor: this.actor.name, days: String(config.days) }) ?? `${this.actor.name} on emergency recovery for ${config.days} days`,
+      );
+    } catch (err: unknown) {
+      handleActionError(err, "Failed to start recovery", "INSPECTRES.ErrorRecoveryFailed", "Could not update recovery status");
+    }
+  }
+
+  static async onOverrideRecoveryDay(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
+    if (!this.isEditable) return;
+    const input = target as HTMLInputElement;
+    const targetDay = Number(input.value);
+    if (isNaN(targetDay) || targetDay < 1) {
+      ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnInvalidDay") ?? "Invalid day number");
+      return;
+    }
+
+    try {
+      const system = this.actor.system as unknown as AgentData;
+      const currentDay = getCurrentDay();
+      const daysElapsed = currentDay - system.recoveryStartedAt;
+      const daysNeeded = Math.max(0, targetDay - system.recoveryStartedAt);
+
+      const updateData = {
+        "system.daysOutOfAction": daysNeeded,
+      } as unknown as Parameters<typeof this.actor.update>[0];
+      await this.actor.update(updateData);
+
+      ui.notifications?.info(
+        game.i18n?.format("INSPECTRES.InfoRecoveryDayOverride", { actor: this.actor.name, day: String(targetDay) }) ?? `${this.actor.name} recovery adjusted to day ${targetDay}`,
+      );
+    } catch (err: unknown) {
+      handleActionError(err, "Failed to override recovery day", "INSPECTRES.ErrorOverrideFailed", "Could not update recovery day");
     }
   }
 }

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -483,7 +483,6 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     try {
       const system = this.actor.system as unknown as AgentData;
       const currentDay = getCurrentDay();
-      const daysElapsed = currentDay - system.recoveryStartedAt;
       const daysNeeded = Math.max(0, targetDay - system.recoveryStartedAt);
 
       const updateData = {

--- a/foundry/src/agent/agent-sheet.hbs
+++ b/foundry/src/agent/agent-sheet.hbs
@@ -201,6 +201,69 @@
         <p class="mission-pool-display">{{system.missionPool}} franchise {{inspectres-plural system.missionPool "die" "dice"}}</p>
       </section>
 
+      <!-- Recovery Status Section -->
+      <section class="inspectres-section inspectres-recovery">
+        <h2>{{localize "INSPECTRES.RecoveryStatus"}}</h2>
+
+        <div class="recovery-info">
+          <div class="status-display">
+            <span class="status-label">{{localize "INSPECTRES.Status"}}:</span>
+            <span class="status-value {{recoveryStatus.status}}">
+              {{#if (eq recoveryStatus.status "dead")}}
+                {{localize "INSPECTRES.RecoveryStatusDead"}}
+              {{else if (eq recoveryStatus.status "recovering")}}
+                {{localize "INSPECTRES.RecoveryStatusRecovering"}} ({{recoveryStatus.daysRemaining}} {{inspectres-plural recoveryStatus.daysRemaining "day" "days"}} left)
+              {{else if (eq recoveryStatus.status "returned")}}
+                {{localize "INSPECTRES.RecoveryStatusReturned"}}
+              {{else}}
+                {{localize "INSPECTRES.RecoveryStatusActive"}}
+              {{/if}}
+            </span>
+          </div>
+
+          {{#if (or system.isDead (gt system.daysOutOfAction 0))}}
+            <div class="recovery-details">
+              {{#if system.isDead}}
+                <p class="recovery-note">{{localize "INSPECTRES.RecoveryNoteDead"}}</p>
+              {{else}}
+                <p class="recovery-note">
+                  {{localize "INSPECTRES.RecoveryNoteRecovering"}}:
+                  <span class="recovery-day">Day {{inspectres-add system.recoveryStartedAt system.daysOutOfAction}}</span>
+                </p>
+              {{/if}}
+            </div>
+          {{/if}}
+        </div>
+
+        {{#if isEditable}}
+          <div class="recovery-controls">
+            {{#if system.isDead}}
+              <button type="button" class="inspectres-recovery-button" data-action="reviveAgent">
+                {{localize "INSPECTRES.ReviveAgent"}}
+              </button>
+            {{else if (gt system.daysOutOfAction 0)}}
+              <div class="recovery-override">
+                <label>
+                  {{localize "INSPECTRES.OverrideRecoveryDay"}}:
+                  <input
+                    type="number"
+                    class="recovery-day-input"
+                    data-action="overrideRecoveryDay"
+                    min="1"
+                    max="365"
+                    value="{{inspectres-add system.recoveryStartedAt system.daysOutOfAction}}"
+                  />
+                </label>
+              </div>
+            {{else}}
+              <button type="button" class="inspectres-recovery-button" data-action="emergencyRecovery">
+                {{localize "INSPECTRES.EmergencyRecovery"}}
+              </button>
+            {{/if}}
+          </div>
+        {{/if}}
+      </section>
+
     </div><!-- /notes tab -->
 
   </div>

--- a/foundry/src/lang/en.json
+++ b/foundry/src/lang/en.json
@@ -284,6 +284,26 @@
     "ConfirmVacationBody": "End mission and begin vacation? This will open the distribution dialog.",
     "WarnNoMissionPool": "No mission pool to distribute.",
     "ErrorDayAdvanceFailed": "Failed to advance day",
-    "ErrorDayRegressFailed": "Failed to revert day"
+    "ErrorDayRegressFailed": "Failed to revert day",
+    "RecoveryStatus": "Recovery Status",
+    "Status": "Status",
+    "RecoveryStatusActive": "Active",
+    "RecoveryStatusDead": "Dead",
+    "RecoveryStatusRecovering": "Recovering",
+    "RecoveryStatusReturned": "Recovered",
+    "RecoveryNoteDead": "Agent is permanently dead. Use Revive to restore.",
+    "RecoveryNoteRecovering": "Agent returns to active duty on",
+    "ReviveAgent": "Revive Agent",
+    "EmergencyRecovery": "Emergency Recovery",
+    "DaysOutOfAction": "Days out of action",
+    "DialogSet": "Set",
+    "OverrideRecoveryDay": "Override recovery end day",
+    "WarnInvalidDay": "Invalid day number",
+    "InfoAgentRevived": "{actor} has been revived",
+    "InfoRecoveryStarted": "{actor} on emergency recovery for {days} day{s}",
+    "InfoRecoveryDayOverride": "{actor} recovery adjusted to day {day}",
+    "ErrorReviveFailed": "Could not revive agent",
+    "ErrorRecoveryFailed": "Could not update recovery status",
+    "ErrorOverrideFailed": "Could not override recovery day"
   }
 }

--- a/foundry/system.json
+++ b/foundry/system.json
@@ -2,7 +2,7 @@
   "id": "inspectres",
   "title": "InSpectres",
   "description": "Paranormal investigation RPG system for Foundry VTT.",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "compatibility": {
     "minimum": "13",
     "verified": "13"


### PR DESCRIPTION
## Summary
Adds discoverable GM controls for agent recovery and death state management on the agent sheet Notes tab.

### Fixed Issues
- #164 — Add GM tools for manual agent recovery/death state management
- #167 — Centralize GM control surfaces (audit for command-line only features)
- #168 — Design GM control UI architecture (distributed approach; recovery controls live on agent sheet)

### Changes
- **Recovery Status Section** on agent sheet Notes tab displays current state (Active/Dead/Recovering/Recovered)
- **Revive Agent** button clears death state and recovery fields
- **Emergency Recovery** dialog allows GM to set custom recovery duration (days out of action + start day)
- **Override Recovery End Day** numeric input allows GM to adjust target recovery day
- Recovery info displays when agent will return (e.g., "Agent will recover on Day X")
- All controls use consistent localization (INSPECTRES.RecoveryStatus, etc.)
- Comprehensive test coverage for all recovery state transitions

### Design Decision
Implements distributed pattern per #168 — recovery controls live on agent sheet (natural location for recovery state), not a centralized dashboard. Future sprints may consolidate high-frequency controls (day advance, mission end) to toolbar if playtest feedback warrants.

### Test Results
✅ All 193 tests passing
✅ Type check passing
✅ Build successful
✅ Pre-PR review: 1 P2 dead-code fix applied, no P0/P1 issues

## Implementation
- Recovery handlers guard with `isEditable` check
- Dialog-based emergency recovery for clear user intent
- Error handling via `handleActionError` pattern
- Localization for all UI strings + fallbacks
- State computed by existing `computeRecoveryStatus()` utility

Closes #164, #167, #168.