### PR TITLE
fix: Recovery controls consolidation and validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,25 @@ Where `$CHILD_ID` from `gh issue view $NUMBER --json id --jq .id`.
 
 ### Milestones
 
-- **Economy: Vacation & Bankruptcy** — stress recovery, debt, financial mechanics
-- **Character: Recovery & Death** — character continuity, death flows, incapacity
-- **Content & Variants: Weird Agents** — special powers, archetypes, content expansions
-- **Infrastructure: Multiplayer & DevTools** — socket sync, real-time features, developer tooling
+Milestones are **categorization labels, not project phases**. They organize issues by domain, not by completion timeline.
+
+**Core game design:**
+- **Core Mechanics** — Skill rolls, stress, cool dice caps, augmentations, edge cases
+- **Content & Variants: Weird Agents** — Weird agent mechanics, special powers, talent restrictions
+- **Economy: Vacation & Bankruptcy** — Vacation mechanics, bankruptcy, financial resource management
+- **Collaboration & Rolls** — Teamwork assists, confessionals, interview workflows, private life rolls
+- **Character: Recovery & Death** — Recovery controls, death/dismemberment, character continuity
+
+**Technical & integration:**
+- **Code Quality & Testing** — Type safety, dead code, test coverage, refactoring
+- **Infrastructure** — Socket sync, logging, performance optimization
+- **UI & UX** — Sheets, dialogs, forms, accessibility, CSS
+- **Foundry Integration** — Foundry API integration, actor dependencies
+
+**Specialized:**
+- **Starting Interview** — Campaign setup flow and GM checklist
+
+**Policy:** Milestones are **never deleted** when all issues are completed. They remain as domain markers for future related work. Issues move into/out of milestones as work is organized; the milestones themselves are permanent organizational structure.
 
 ## Versioning
 

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -152,6 +152,24 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
         });
       }, { signal: controller.signal });
     }
+
+    // recovery-day-input: change event for overrideRecoveryDay (not automatic like form inputs with name="...")
+    for (const el of this.element.querySelectorAll<HTMLInputElement>(".recovery-day-input")) {
+      el.addEventListener("change", (event: Event) => {
+        const target = event.target as HTMLInputElement;
+        void AgentSheet.onOverrideRecoveryDay.call(this, event, target).catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error("Failed to override recovery day for agent", {
+            actorId: this.actor.id,
+            actorName: this.actor.name,
+            targetValue: target.value,
+            error: err,
+            errorMessage: message,
+          });
+          handleActionError(err, "Failed to override recovery day", "INSPECTRES.ErrorUpdateFailed", "Could not update recovery");
+        });
+      }, { signal: controller.signal });
+    }
   }
 
   static async onSkillRoll(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -507,7 +507,8 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     if (!this.isEditable) return;
     const input = target as HTMLInputElement;
     const targetDay = Number(input.value);
-    if (isNaN(targetDay) || targetDay < 1) {
+    const MAX_RECOVERY_DAY = 365;
+    if (!Number.isInteger(targetDay) || isNaN(targetDay) || targetDay < 1 || targetDay > MAX_RECOVERY_DAY) {
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnInvalidDay") ?? "Invalid day number");
       return;
     }
@@ -515,7 +516,11 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     try {
       const system = this.actor.system as unknown as AgentData;
       const currentDay = getCurrentDay();
-      const daysNeeded = Math.max(0, targetDay - system.recoveryStartedAt);
+      if (targetDay < system.recoveryStartedAt) {
+        ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnRecoveryDayBeforeStart") ?? "Target day must be on or after the recovery start day");
+        return;
+      }
+      const daysNeeded = targetDay - system.recoveryStartedAt;
 
       const updateData = {
         "system.daysOutOfAction": daysNeeded,

--- a/foundry/src/agent/agent-sheet.hbs
+++ b/foundry/src/agent/agent-sheet.hbs
@@ -163,46 +163,6 @@
         </button>
       </section>
 
-    </div><!-- /stats tab -->
-
-    <!-- Notes Tab -->
-    <div class="tab" data-tab="notes" id="tab-notes" role="tabpanel">
-
-      <!-- Characteristics Section -->
-      <section class="inspectres-section">
-        <h2>{{localize "INSPECTRES.Characteristics"}}</h2>
-        <div class="characteristics-list">
-          {{#each system.characteristics as |characteristic idx|}}
-            <div class="characteristic-row">
-              <input
-                type="checkbox"
-                name="system.characteristics.{{idx}}.used"
-                title="{{localize "INSPECTRES.TooltipCharacteristicUsed"}}"
-                {{#if characteristic.used}}checked{{/if}}
-                class="characteristic-used"
-              />
-              <input
-                type="text"
-                name="system.characteristics.{{idx}}.text"
-                value="{{characteristic.text}}"
-                placeholder="Characteristic text"
-                class="characteristic-text"
-              />
-              <button type="button" class="btn-remove" data-action="removeCharacteristic" data-idx="{{idx}}" aria-label="{{localize "INSPECTRES.AriaLabel.RemoveCharacteristic"}}">
-                ✕
-              </button>
-            </div>
-          {{/each}}
-        </div>
-        <button type="button" class="btn-add" data-action="addCharacteristic">{{localize "INSPECTRES.AddCharacteristic"}}</button>
-      </section>
-
-      <!-- Mission Pool Section -->
-      <section class="inspectres-section">
-        <h2>{{localize "INSPECTRES.MissionPool"}}</h2>
-        <p class="mission-pool-display">{{system.missionPool}} franchise {{inspectres-plural system.missionPool "die" "dice"}}</p>
-      </section>
-
       <!-- Recovery Status Section -->
       <section class="inspectres-section inspectres-recovery">
         <h2>{{localize "INSPECTRES.RecoveryStatus"}}</h2>
@@ -264,6 +224,46 @@
             {{/if}}
           </div>
         {{/if}}
+      </section>
+
+    </div><!-- /stats tab -->
+
+    <!-- Notes Tab -->
+    <div class="tab" data-tab="notes" id="tab-notes" role="tabpanel">
+
+      <!-- Characteristics Section -->
+      <section class="inspectres-section">
+        <h2>{{localize "INSPECTRES.Characteristics"}}</h2>
+        <div class="characteristics-list">
+          {{#each system.characteristics as |characteristic idx|}}
+            <div class="characteristic-row">
+              <input
+                type="checkbox"
+                name="system.characteristics.{{idx}}.used"
+                title="{{localize "INSPECTRES.TooltipCharacteristicUsed"}}"
+                {{#if characteristic.used}}checked{{/if}}
+                class="characteristic-used"
+              />
+              <input
+                type="text"
+                name="system.characteristics.{{idx}}.text"
+                value="{{characteristic.text}}"
+                placeholder="Characteristic text"
+                class="characteristic-text"
+              />
+              <button type="button" class="btn-remove" data-action="removeCharacteristic" data-idx="{{idx}}" aria-label="{{localize "INSPECTRES.AriaLabel.RemoveCharacteristic"}}">
+                ✕
+              </button>
+            </div>
+          {{/each}}
+        </div>
+        <button type="button" class="btn-add" data-action="addCharacteristic">{{localize "INSPECTRES.AddCharacteristic"}}</button>
+      </section>
+
+      <!-- Mission Pool Section -->
+      <section class="inspectres-section">
+        <h2>{{localize "INSPECTRES.MissionPool"}}</h2>
+        <p class="mission-pool-display">{{system.missionPool}} franchise {{inspectres-plural system.missionPool "die" "dice"}}</p>
       </section>
 
     </div><!-- /notes tab -->


### PR DESCRIPTION
## Summary

Move recovery controls to Stats tab for improved GM UX during gameplay. Add comprehensive input validation for recovery day override to prevent edge cases.

### Changes

- **#236**: Move recovery status section from Notes tab to Stats tab
- **#239**: Wire overrideRecoveryDay input change listener in AgentSheet._onRender
- **#222**: Power field already properly persisted via AgentDataModel.SchemaField
- **Validation**: Add integer, upper-bound, and min-recovery-day checks to prevent silent failures

### Acceptance Criteria

- Recovery banner, Revive, Emergency Recovery, Override buttons all on Stats tab
- overrideRecoveryDay input fires change events and updates actor
- Power field persists across reload (DataModel already supports this)
- Recovery day input validates: integer, 1–365 range, >= recoveryStartedAt

### Testing

- All 215 tests pass
- Type checking clean
- No regressions in existing recovery logic

Closes #294
Closes #222
Closes #236
Closes #239