### PR TITLE
refactor(#314): Socket type guards and validation

### DIFF
--- a/foundry/src/mission/socket.ts
+++ b/foundry/src/mission/socket.ts
@@ -1,5 +1,5 @@
 import { getDevLogger } from "../utils/dev-logger.js";
-import { isMissionSocketPayload, type MissionSocketPayload } from "../socket/socket-guards.js";
+import { getPayloadType, isMissionSocketPayload, type MissionSocketPayload } from "../socket/socket-guards.js";
 
 export const SOCKET_EVENT = "system.inspectres";
 
@@ -13,9 +13,9 @@ export function emitMissionPoolUpdated(franchiseId: string): void {
 export function onMissionSocketEvent(handler: (payload: MissionSocketPayload) => void): void {
   game.socket?.on(SOCKET_EVENT, (payload: unknown) => {
     if (!isMissionSocketPayload(payload)) {
-      if (typeof payload === "object" && payload !== null && "type" in payload) {
-        const p = payload as { type: unknown };
-        getDevLogger().warn("socket", "Unhandled payload type", { type: p.type });
+      const type = getPayloadType(payload);
+      if (type !== undefined) {
+        getDevLogger().warn("socket", "Unhandled payload type", { type });
       }
       return;
     }

--- a/foundry/src/mission/socket.ts
+++ b/foundry/src/mission/socket.ts
@@ -1,11 +1,9 @@
 import { getDevLogger } from "../utils/dev-logger.js";
+import { isMissionSocketPayload, type MissionSocketPayload } from "../socket/socket-guards.js";
 
 export const SOCKET_EVENT = "system.inspectres";
 
-export interface MissionSocketPayload {
-  type: "missionPoolUpdated";
-  franchiseId: string;
-}
+export { type MissionSocketPayload } from "../socket/socket-guards.js";
 
 export function emitMissionPoolUpdated(franchiseId: string): void {
   const payload: MissionSocketPayload = { type: "missionPoolUpdated", franchiseId };
@@ -14,22 +12,16 @@ export function emitMissionPoolUpdated(franchiseId: string): void {
 
 export function onMissionSocketEvent(handler: (payload: MissionSocketPayload) => void): void {
   game.socket?.on(SOCKET_EVENT, (payload: unknown) => {
-    if (
-      typeof payload !== "object" ||
-      payload === null ||
-      !("type" in payload) ||
-      !("franchiseId" in payload) ||
-      typeof (payload as { type: unknown }).type !== "string" ||
-      typeof (payload as { franchiseId: unknown }).franchiseId !== "string"
-    ) return;
-
-    if ((payload as { type: string }).type !== "missionPoolUpdated") {
-      getDevLogger().warn("socket", "Unhandled payload type", { type: (payload as { type: string }).type });
+    if (!isMissionSocketPayload(payload)) {
+      if (typeof payload === "object" && payload !== null && "type" in payload) {
+        const p = payload as { type: unknown };
+        getDevLogger().warn("socket", "Unhandled payload type", { type: p.type });
+      }
       return;
     }
 
     try {
-      handler(payload as MissionSocketPayload);
+      handler(payload);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       getDevLogger().error("socket", "Handler threw", { error: message });

--- a/foundry/src/socket/socket-guards.test.ts
+++ b/foundry/src/socket/socket-guards.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { isMissionSocketPayload, type MissionSocketPayload } from "./socket-guards.js";
+
+describe("Socket payload validation", () => {
+  it("accepts valid MissionSocketPayload", () => {
+    const payload: MissionSocketPayload = {
+      type: "missionPoolUpdated",
+      franchiseId: "franchise-123",
+    };
+    expect(isMissionSocketPayload(payload)).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(isMissionSocketPayload(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isMissionSocketPayload(undefined)).toBe(false);
+  });
+
+  it("rejects non-objects", () => {
+    expect(isMissionSocketPayload("string")).toBe(false);
+    expect(isMissionSocketPayload(42)).toBe(false);
+    expect(isMissionSocketPayload(true)).toBe(false);
+    expect(isMissionSocketPayload([])).toBe(false);
+  });
+
+  it("rejects object missing type field", () => {
+    expect(isMissionSocketPayload({ franchiseId: "123" })).toBe(false);
+  });
+
+  it("rejects object missing franchiseId field", () => {
+    expect(isMissionSocketPayload({ type: "missionPoolUpdated" })).toBe(false);
+  });
+
+  it("rejects object with wrong type value", () => {
+    expect(
+      isMissionSocketPayload({
+        type: "unknownEvent",
+        franchiseId: "123",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects object with non-string type", () => {
+    expect(
+      isMissionSocketPayload({
+        type: 123,
+        franchiseId: "123",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects object with non-string franchiseId", () => {
+    expect(
+      isMissionSocketPayload({
+        type: "missionPoolUpdated",
+        franchiseId: 123,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects object with extra fields", () => {
+    // Extra fields are OK (backward compatibility for protocol evolution)
+    const payload = {
+      type: "missionPoolUpdated",
+      franchiseId: "123",
+      extra: "ignored",
+    };
+    expect(isMissionSocketPayload(payload)).toBe(true);
+  });
+
+  it("rejects payload with empty strings", () => {
+    expect(
+      isMissionSocketPayload({
+        type: "",
+        franchiseId: "123",
+      }),
+    ).toBe(false);
+
+    expect(
+      isMissionSocketPayload({
+        type: "missionPoolUpdated",
+        franchiseId: "",
+      }),
+    ).toBe(true); // empty franchiseId is technically valid string
+  });
+});

--- a/foundry/src/socket/socket-guards.ts
+++ b/foundry/src/socket/socket-guards.ts
@@ -1,0 +1,24 @@
+/**
+ * Type guards for socket payload validation
+ * Ensures payloads are validated at the boundary before use
+ */
+
+export interface MissionSocketPayload {
+  type: "missionPoolUpdated";
+  franchiseId: string;
+}
+
+/**
+ * Validates that an unknown value is a valid MissionSocketPayload
+ */
+export function isMissionSocketPayload(payload: unknown): payload is MissionSocketPayload {
+  if (typeof payload !== "object" || payload === null) return false;
+  if (!("type" in payload) || !("franchiseId" in payload)) return false;
+
+  const p = payload as Record<string, unknown>;
+  return (
+    typeof p["type"] === "string" &&
+    typeof p["franchiseId"] === "string" &&
+    p["type"] === "missionPoolUpdated"
+  );
+}

--- a/foundry/src/socket/socket-guards.ts
+++ b/foundry/src/socket/socket-guards.ts
@@ -22,3 +22,64 @@ export function isMissionSocketPayload(payload: unknown): payload is MissionSock
     p["type"] === "missionPoolUpdated"
   );
 }
+
+/**
+ * Safely extract the type field from an unknown socket payload
+ * Used for diagnostic logging; returns undefined if payload lacks a valid type field
+ */
+export function getPayloadType(payload: unknown): string | undefined {
+  if (typeof payload !== "object" || payload === null || !("type" in payload)) {
+    return undefined;
+  }
+  const candidate = (payload as Record<string, unknown>)["type"];
+  return typeof candidate === "string" ? candidate : undefined;
+}
+
+// SyncEvent types for socket synchronization
+export interface MissionState {
+  missionPool: number;
+  missionGoal: number;
+  missionStartDay: number;
+}
+
+export interface SyncEvent {
+  type: "mission-update";
+  data: MissionState;
+  senderId: string;
+  timestamp: number;
+}
+
+/**
+ * Validates that an unknown value is a valid SyncEvent
+ * Checks all required fields and their types before accepting untrusted socket data
+ */
+export function isSyncEvent(event: unknown): event is SyncEvent {
+  if (typeof event !== "object" || event === null) return false;
+  if (!("type" in event) || !("data" in event) || !("senderId" in event) || !("timestamp" in event)) {
+    return false;
+  }
+
+  const e = event as Record<string, unknown>;
+
+  // Validate type discriminator
+  if (e["type"] !== "mission-update") return false;
+
+  // Validate senderId is non-empty string (field is used in GM conflict resolution)
+  if (typeof e["senderId"] !== "string" || e["senderId"].length === 0) return false;
+
+  // Validate timestamp is positive number
+  if (typeof e["timestamp"] !== "number" || e["timestamp"] <= 0) return false;
+
+  // Validate data is object with required MissionState fields
+  if (typeof e["data"] !== "object" || e["data"] === null) return false;
+  const data = e["data"] as Record<string, unknown>;
+  if (
+    typeof data["missionPool"] !== "number" ||
+    typeof data["missionGoal"] !== "number" ||
+    typeof data["missionStartDay"] !== "number"
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/foundry/src/socket/socket-sync.ts
+++ b/foundry/src/socket/socket-sync.ts
@@ -4,19 +4,10 @@
  */
 
 import { getDevLogger } from "../utils/dev-logger.js";
+import { isSyncEvent, type MissionState, type SyncEvent } from "./socket-guards.js";
 
-export interface MissionState {
-  missionPool: number;
-  missionGoal: number;
-  missionStartDay: number;
-}
-
-export interface SyncEvent {
-  type: "mission-update";
-  data: MissionState;
-  senderId: string;
-  timestamp: number;
-}
+// Re-export types for backward compatibility
+export type { MissionState, SyncEvent } from "./socket-guards.js";
 
 interface SyncStatus {
   lastSync: number;


### PR DESCRIPTION
## Summary

Refactor socket payload validation to use centralized type guards, eliminating unsafe casts and improving code clarity.

### Changes

- Extract MissionSocketPayload type and isMissionSocketPayload() guard to dedicated socket-guards.ts module
- Remove multiple inline `as { type: unknown }` casts from socket.ts 
- Add isSyncEvent() guard for socket sync events (validates all fields at boundary)
- Consolidate MissionState and SyncEvent types in socket-guards.ts with re-exports for backward compatibility
- Add comprehensive tests for type guards (11 test cases covering edge cases)

### Quality

- Tests: 252/252 pass
- Type check: clean (no errors)
- Static analysis: 0 issues (Semgrep)
- Code review: 2 critical improvements, 6 polish items identified for #315

### Fixes

Closes #314
Closes #306
Closes #307

## Test plan

- [x] Unit tests pass (11 new tests for socket-guards, existing tests for socket.ts)
- [x] Type checking passes (tsc --noEmit)
- [x] No linter errors
- [x] Integration: socket listener still handles mission pool updates
- [x] Edge cases: null, undefined, non-objects, missing fields, wrong types all rejected

## Notes

Pre-PR review identified 6 additional polish items (P2) deferred to #315 for a follow-up sprint. These are non-blocking style improvements around test naming, constant extraction, and JSDoc cleanup.