### PR TITLE
Sprint #358: Distribution dialog cleanup

### DIFF
--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -2,7 +2,7 @@ import { type FranchiseData } from "./franchise-schema.js";
 import { executeBankRoll, executeClientRoll } from "../rolls/roll-executor.js";
 import { MissionTrackerApp } from "../mission/MissionTrackerApp.js";
 import { handleActionError } from "../utils/ui-errors.js";
-import { createDistributionDialog } from "../utils/distribution-dialog.js";
+import { promptDistribution } from "../utils/distribution-dialog.js";
 import { activateTabs } from "../utils/sheet-tabs.js";
 import { enterDebtMode, attemptLoanRepayment } from "./bankruptcy-handler.js";
 import { emitMissionPoolUpdated } from "../mission/socket.js";
@@ -175,11 +175,9 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
     const total = system.missionPool;
     const players = (game.users?.filter((u) => u.active && !u.isGM) ?? []).map((u) => ({ id: u.id, name: u.name ?? u.id }));
 
-    const dialogConfig = await createDistributionDialog({ missionPool: total, players });
-    const result = await foundry.applications.api.DialogV2.wait(dialogConfig);
+    const distribution = await promptDistribution({ missionPool: total, players });
 
-    if (result === null || result === undefined) return;
-    const distribution = result as Record<string, number>;
+    if (distribution === null) return;
 
     const refreshedSystem = this.actor.system as unknown as FranchiseData;
     const refreshedTotal = refreshedSystem.missionPool;

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -1,6 +1,6 @@
 import { findFranchiseActor, franchiseSystemData } from "../franchise/franchise-utils.js";
 import { handleActionError } from "../utils/ui-errors.js";
-import { createDistributionDialog } from "../utils/distribution-dialog.js";
+import { promptDistribution } from "../utils/distribution-dialog.js";
 import { emitMissionPoolUpdated } from "./socket.js";
 import { getCurrentDaySetting } from "../utils/settings-utils.js";
 
@@ -80,11 +80,9 @@ export class MissionTrackerApp extends foundry.applications.api.ApplicationV2 {
     const total = system.missionPool;
     const players = (game.users?.filter((u) => u.active && !u.isGM) ?? []).map((u) => ({ id: u.id, name: u.name ?? u.id }));
 
-    const dialogConfig = await createDistributionDialog({ missionPool: total, players });
-    const result = await foundry.applications.api.DialogV2.wait(dialogConfig);
+    const distribution = await promptDistribution({ missionPool: total, players });
 
-    if (result === null || result === undefined) return;
-    const distribution = result as Record<string, number>;
+    if (distribution === null) return;
 
     // Verify franchise still exists after dialog interaction. If it was deleted,
     // throw error with context instead of returning silently (prevents data loss).

--- a/foundry/src/utils/distribution-dialog.test.ts
+++ b/foundry/src/utils/distribution-dialog.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createDistributionDialog, type PlayerInfo } from "./distribution-dialog.js";
+import { buildDistributionConfig, type PlayerInfo } from "./distribution-dialog.js";
 
-describe("createDistributionDialog", () => {
+describe("buildDistributionConfig", () => {
+  const mockDialog = {
+    querySelector: vi.fn(),
+  } as unknown as HTMLDialogElement;
+
   beforeEach(() => {
     // Mock foundry globals
     (globalThis as Record<string, unknown>)["game"] = {
@@ -21,6 +25,7 @@ describe("createDistributionDialog", () => {
   });
 
   afterEach(() => {
+    vi.clearAllMocks();
     delete (globalThis as Record<string, unknown>)["game"];
     delete (globalThis as Record<string, unknown>)["foundry"];
   });
@@ -30,7 +35,7 @@ describe("createDistributionDialog", () => {
       { id: "user1", name: "Alice" },
       { id: "user2", name: "Bob" },
     ];
-    const result = await createDistributionDialog({ missionPool: 10, players });
+    const result = await buildDistributionConfig({ missionPool: 10, players });
     expect(result).toHaveProperty("content");
     const content = result.content as string;
     // Should use for/id pairing, not wrapping labels
@@ -45,7 +50,7 @@ describe("createDistributionDialog", () => {
       { id: "user1", name: "Alice" },
       { id: "user2", name: "Bob" },
     ];
-    const result = await createDistributionDialog({ missionPool: 10, players });
+    const result = await buildDistributionConfig({ missionPool: 10, players });
     const content = result.content as string;
     expect(content).toContain("Alice");
     expect(content).toContain("Bob");
@@ -53,7 +58,7 @@ describe("createDistributionDialog", () => {
 
   it("includes dialog buttons", async () => {
     const players: PlayerInfo[] = [{ id: "user1", name: "Alice" }];
-    const result = await createDistributionDialog({ missionPool: 5, players });
+    const result = await buildDistributionConfig({ missionPool: 5, players });
     expect(result.buttons).toBeDefined();
     expect(Array.isArray(result.buttons)).toBe(true);
     const actions = result.buttons?.map((b) => b.action);
@@ -62,7 +67,7 @@ describe("createDistributionDialog", () => {
   });
 
   it("handles no players gracefully", async () => {
-    const result = await createDistributionDialog({ missionPool: 5, players: [] });
+    const result = await buildDistributionConfig({ missionPool: 5, players: [] });
     const content = result.content as string;
     expect(content).toContain("No active players");
   });
@@ -71,7 +76,7 @@ describe("createDistributionDialog", () => {
     const players: PlayerInfo[] = [
       { id: "user1", name: "<img src=x onerror='alert(1)'>" },
     ];
-    const result = await createDistributionDialog({ missionPool: 5, players });
+    const result = await buildDistributionConfig({ missionPool: 5, players });
     const content = result.content as string;
     // Should contain escaped entities, not raw HTML
     expect(content).toContain("&lt;img");

--- a/foundry/src/utils/distribution-dialog.ts
+++ b/foundry/src/utils/distribution-dialog.ts
@@ -8,7 +8,7 @@ export interface DistributionDialogOptions {
   players: PlayerInfo[];
 }
 
-export interface DistributionDialogResult {
+interface DialogConfig {
   content: string;
   window?: { title: string };
   buttons?: Array<{
@@ -24,7 +24,7 @@ export interface DistributionDialogResult {
   rejectClose?: boolean;
 }
 
-export async function createDistributionDialog(opts: DistributionDialogOptions): Promise<DistributionDialogResult> {
+export async function buildDistributionConfig(opts: DistributionDialogOptions): Promise<DialogConfig> {
   const { missionPool, players } = opts;
 
   const playerInputs = players
@@ -91,4 +91,11 @@ export async function createDistributionDialog(opts: DistributionDialogOptions):
       },
     ],
   };
+}
+
+export async function promptDistribution(opts: DistributionDialogOptions): Promise<Record<string, number> | null> {
+  const config = await buildDistributionConfig(opts);
+  const result = await foundry.applications.api.DialogV2.wait(config);
+  if (result === null || result === undefined) return null;
+  return result as Record<string, number>;
 }


### PR DESCRIPTION
## Summary

Consolidates 4 related refactoring issues into a single PR:
- #351: Extract `promptDistribution()` helper
- #352: Remove unused `DistributionDialogResult` interface
- #353: Rename `createDistributionDialog` → `buildDistributionConfig`
- #354: Add afterEach teardown to tests

## Changes

**distribution-dialog.ts:**
- Renamed `createDistributionDialog()` → `buildDistributionConfig()` (clarifies it builds config, not creates dialog)
- Extracted new `promptDistribution()` helper that encapsulates dialog machinery (DialogV2.wait pattern)
- Made `DialogConfig` interface private (internal only, not exported)
- Removed unused `DistributionDialogResult` type

**distribution-dialog.test.ts:**
- Updated imports and test blocks for renamed function
- Enhanced afterEach cleanup with vi.clearAllMocks()

**FranchiseSheet.ts & MissionTrackerApp.ts:**
- Updated imports to use new `promptDistribution` helper
- Simplified dialog caller code from 3 lines → 1 line per callsite

## Test Coverage

All 5 existing tests passing:
- Render form with for/id label pairing
- Include all players in dialog
- Include confirm/cancel buttons
- Handle empty player list gracefully
- Escape player names to prevent HTML injection

## Quality

- No new issues from code-reviewer, semgrep, silent-failure-hunter
- Code-simplifier analysis deferred (pre-existing patterns, outside sprint scope)

---

Closes #351
Closes #352
Closes #353
Closes #354
Closes #358