### PR TITLE
Add franchise actor validation to client roll (#274)

### DIFF
--- a/foundry/src/rolls/roll-executor.test.ts
+++ b/foundry/src/rolls/roll-executor.test.ts
@@ -466,6 +466,16 @@ describe("executeStressRoll", () => {
 // ---------------------------------------------------------------------------
 
 describe("executeClientRoll", () => {
+  it("throws error when franchise system is null or not an object", async () => {
+    const badFranchise: RollActor = {
+      id: "bad-123",
+      name: "Invalid",
+      system: null as unknown as object,
+      update: vi.fn(),
+    };
+    await expect(executeClientRoll(badFranchise)).rejects.toThrow(/franchise|actor\.system/i);
+  });
+
   it("posts a chat message without modifying franchise", async () => {
     (globalThis as unknown as { Roll: typeof MockRoll }).Roll = class extends MockRoll {
       constructor(formula: string) {

--- a/foundry/src/rolls/roll-executor.test.ts
+++ b/foundry/src/rolls/roll-executor.test.ts
@@ -473,7 +473,7 @@ describe("executeClientRoll", () => {
       system: null as unknown as object,
       update: vi.fn(),
     };
-    await expect(executeClientRoll(badFranchise)).rejects.toThrow(/franchise|actor\.system/i);
+    await expect(executeClientRoll(badFranchise)).rejects.toThrow(/Client roll requires valid franchise/);
   });
 
   it("posts a chat message without modifying franchise", async () => {

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -693,12 +693,19 @@ export async function executeClientRoll(franchise: RollActor): Promise<void> {
   // Client rolls require a franchise actor — cannot be run as a standalone tool.
   // The franchise provides the GM context for generating random client attributes.
   // #274: Validate that franchise system is valid before proceeding.
-  let franchiseSystem: FranchiseData;
   try {
-    franchiseSystem = getActorSystem<FranchiseData>(franchise);
+    getActorSystem<FranchiseData>(franchise);
   } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[INSPECTRES] Client roll validation failed:", {
+      franchiseId: franchise.id,
+      franchiseName: franchise.name,
+      error: err,
+      errorMessage: message,
+    });
+    ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorClientRollFailed") ?? "Client roll requires valid franchise actor");
     throw new Error(
-      `Client roll requires a valid franchise actor with complete system data. Received: ${franchise.name} (ID: ${franchise.id}). Cannot run client roll as a standalone tool.`,
+      `Client roll requires valid franchise actor with system data. ${franchise.name} (ID: ${franchise.id}): ${message}`,
     );
   }
 

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -690,6 +690,18 @@ export function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): stri
 // ---------------------------------------------------------------------------
 
 export async function executeClientRoll(franchise: RollActor): Promise<void> {
+  // Client rolls require a franchise actor — cannot be run as a standalone tool.
+  // The franchise provides the GM context for generating random client attributes.
+  // #274: Validate that franchise system is valid before proceeding.
+  let franchiseSystem: FranchiseData;
+  try {
+    franchiseSystem = getActorSystem<FranchiseData>(franchise);
+  } catch (err: unknown) {
+    throw new Error(
+      `Client roll requires a valid franchise actor with complete system data. Received: ${franchise.name} (ID: ${franchise.id}). Cannot run client roll as a standalone tool.`,
+    );
+  }
+
   const attributes = ["personality", "clientType", "occurrence", "location"] as const;
   const rolls: Roll[] = [];
   const generated: Record<string, string> = {};


### PR DESCRIPTION
## Summary
Adds validation to `executeClientRoll()` to ensure client rolls require a valid franchise actor and cannot be run as a standalone tool. Client rolls need franchise context to generate random client attributes.

## Changes
- Validates franchise actor's system data on entry via `getActorSystem()` 
- Provides clear, actionable error message if franchise is invalid
- Logs errors to console with structured context for debugging
- Shows user-facing notification when client roll fails
- Follows established error handling pattern in roll-executor.ts

## Test Coverage
- New test validates that null/invalid franchise system throws expected error
- All existing tests pass (416 passed, 2 skipped, 2 todo)

## Deferred Work
Found systematic issue during review: multiple other functions call `getActorSystem()` without try-catch protection (franchise-utils.ts, bankruptcy-handler.ts, FranchiseSheet.ts). Recommend separate PR to add consistent error handling across franchise module.

Fixes #274