### PR TITLE
test(e2e): capture browser console errors on test failure

### DIFF
--- a/foundry/src/__tests__/console-capture.test.ts
+++ b/foundry/src/__tests__/console-capture.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the E2E console capture helper.
+ *
+ * The Playwright fixture wires page.on("console") and page.on("pageerror")
+ * into a buffer and attaches the buffered log to the test on failure. This
+ * file tests the buffering/formatting layer in isolation — the Playwright
+ * integration itself is exercised by the live E2E suite.
+ */
+import { describe, expect, it } from "vitest";
+import { ConsoleBuffer, formatConsoleEntry, formatPageError } from "./e2e/console-capture";
+
+describe("ConsoleBuffer", () => {
+  it("starts empty", () => {
+    const buf = new ConsoleBuffer();
+    expect(buf.lines).toEqual([]);
+    expect(buf.isEmpty()).toBe(true);
+  });
+
+  it("captures error and warning console entries", () => {
+    const buf = new ConsoleBuffer();
+    buf.recordConsole("error", "boom");
+    buf.recordConsole("warning", "soft boom");
+    expect(buf.lines).toHaveLength(2);
+    expect(buf.lines[0]).toContain("[error]");
+    expect(buf.lines[0]).toContain("boom");
+    expect(buf.lines[1]).toContain("[warning]");
+  });
+
+  it("ignores non-error/warning console types by default", () => {
+    const buf = new ConsoleBuffer();
+    buf.recordConsole("log", "noise");
+    buf.recordConsole("info", "noise");
+    buf.recordConsole("debug", "noise");
+    expect(buf.isEmpty()).toBe(true);
+  });
+
+  it("captures uncaught page errors with stack traces", () => {
+    const buf = new ConsoleBuffer();
+    const err = new Error("unhandled");
+    err.stack = "Error: unhandled\n    at thing.js:1:1";
+    buf.recordPageError(err);
+    expect(buf.lines).toHaveLength(1);
+    const [line] = buf.lines;
+    expect(line).toContain("[pageerror]");
+    expect(line).toContain("unhandled");
+    expect(line).toContain("at thing.js:1:1");
+  });
+
+  it("captures page errors that lack a stack", () => {
+    const buf = new ConsoleBuffer();
+    const err = new Error("no stack");
+    delete err.stack;
+    buf.recordPageError(err);
+    expect(buf.lines[0]).toContain("no stack");
+  });
+
+  it("renders all captured entries as a newline-joined string", () => {
+    const buf = new ConsoleBuffer();
+    buf.recordConsole("error", "first");
+    buf.recordConsole("warning", "second");
+    const rendered = buf.toString();
+    expect(rendered.split("\n")).toHaveLength(2);
+    expect(rendered).toContain("first");
+    expect(rendered).toContain("second");
+  });
+});
+
+describe("formatConsoleEntry", () => {
+  it("prefixes the message with the bracketed type", () => {
+    expect(formatConsoleEntry("error", "the rock cried out no hiding place")).toBe(
+      "[error] the rock cried out no hiding place",
+    );
+  });
+});
+
+describe("formatPageError", () => {
+  it("includes message and stack on separate lines when stack is present", () => {
+    const err = new Error("kaboom");
+    err.stack = "Error: kaboom\n    at file.js:1:1";
+    const out = formatPageError(err);
+    expect(out).toBe("[pageerror] kaboom\nError: kaboom\n    at file.js:1:1");
+  });
+
+  it("omits the stack section when stack is missing", () => {
+    const err = new Error("just message");
+    delete err.stack;
+    expect(formatPageError(err)).toBe("[pageerror] just message");
+  });
+});

--- a/foundry/src/__tests__/e2e/console-capture.ts
+++ b/foundry/src/__tests__/e2e/console-capture.ts
@@ -1,0 +1,47 @@
+/**
+ * Buffers browser-side console errors/warnings and uncaught exceptions
+ * for the Playwright fixture. The fixture wires page.on("console") and
+ * page.on("pageerror") into a {@link ConsoleBuffer}, then attaches the
+ * buffered text to failing tests via testInfo.attach.
+ *
+ * Kept in a standalone module so the formatting/buffering logic can be
+ * unit-tested without spinning up Playwright or a Foundry server.
+ */
+
+const CAPTURED_CONSOLE_TYPES: ReadonlySet<string> = new Set(["error", "warning"]);
+
+export function formatConsoleEntry(type: string, text: string): string {
+  return `[${type}] ${text}`;
+}
+
+export function formatPageError(err: Error): string {
+  if (err.stack) {
+    return `[pageerror] ${err.message}\n${err.stack}`;
+  }
+  return `[pageerror] ${err.message}`;
+}
+
+export class ConsoleBuffer {
+  private readonly entries: string[] = [];
+
+  get lines(): readonly string[] {
+    return this.entries;
+  }
+
+  isEmpty(): boolean {
+    return this.entries.length === 0;
+  }
+
+  recordConsole(type: string, text: string): void {
+    if (!CAPTURED_CONSOLE_TYPES.has(type)) return;
+    this.entries.push(formatConsoleEntry(type, text));
+  }
+
+  recordPageError(err: Error): void {
+    this.entries.push(formatPageError(err));
+  }
+
+  toString(): string {
+    return this.entries.join("\n");
+  }
+}

--- a/foundry/src/__tests__/e2e/fixtures.ts
+++ b/foundry/src/__tests__/e2e/fixtures.ts
@@ -91,10 +91,18 @@ export const test = base.extend({
     await use(page);
 
     if (testInfo.status !== testInfo.expectedStatus && !consoleBuffer.isEmpty()) {
-      await testInfo.attach("browser-console.log", {
-        body: consoleBuffer.toString(),
-        contentType: "text/plain",
-      });
+      try {
+        await testInfo.attach("browser-console.log", {
+          body: consoleBuffer.toString(),
+          contentType: "text/plain",
+        });
+      } catch (err: unknown) {
+        // Don't let an attachment failure mask the actual test failure — that's
+        // the whole point of capturing the buffer. Log and move on so the
+        // original assertion error remains the reported result.
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`Failed to attach browser-console.log: ${message}`);
+      }
     }
   },
 });

--- a/foundry/src/__tests__/e2e/fixtures.ts
+++ b/foundry/src/__tests__/e2e/fixtures.ts
@@ -1,4 +1,5 @@
 import { test as base, expect, type Page } from "@playwright/test";
+import { ConsoleBuffer } from "./console-capture";
 
 const JOIN_TIMEOUT = 30_000;
 const READY_TIMEOUT = 60_000;
@@ -47,14 +48,28 @@ async function openFranchiseSheet(page: Page): Promise<void> {
  *
  * Foundry sessions don't survive across browser contexts, so the auto-launched world
  * places each fresh context on /join. This fixture:
- *   1. Joins the game as Gamemaster.
- *   2. Waits for `game.ready`.
- *   3. Dismisses permanent startup notifications.
- *   4. Unpauses the game.
- *   5. Opens a franchise sheet so DOM elements expected by tests (tabs, inputs, etc.) exist.
+ *   1. Subscribes to browser console errors/warnings and uncaught page errors.
+ *   2. Joins the game as Gamemaster.
+ *   3. Waits for `game.ready`.
+ *   4. Dismisses permanent startup notifications.
+ *   5. Unpauses the game.
+ *   6. Opens a franchise sheet so DOM elements expected by tests (tabs, inputs, etc.) exist.
+ *
+ * On failure, the captured console log is attached to the Playwright report so
+ * browser-side errors (validation, render exceptions, hook failures) surface
+ * directly in the test output instead of requiring a manual repro. See #428.
  */
 export const test = base.extend({
-  page: async ({ page }, use) => {
+  page: async ({ page }, use, testInfo) => {
+    const consoleBuffer = new ConsoleBuffer();
+
+    page.on("console", (msg) => {
+      consoleBuffer.recordConsole(msg.type(), msg.text());
+    });
+    page.on("pageerror", (err) => {
+      consoleBuffer.recordPageError(err);
+    });
+
     await page.goto("/", { waitUntil: "domcontentloaded" });
 
     if (page.url().includes("/join")) {
@@ -74,6 +89,13 @@ export const test = base.extend({
     await openFranchiseSheet(page);
 
     await use(page);
+
+    if (testInfo.status !== testInfo.expectedStatus && !consoleBuffer.isEmpty()) {
+      await testInfo.attach("browser-console.log", {
+        body: consoleBuffer.toString(),
+        contentType: "text/plain",
+      });
+    }
   },
 });
 


### PR DESCRIPTION
Fixes #428

## Summary
- Add `ConsoleBuffer` helper that buffers browser console errors/warnings and uncaught `pageerror` exceptions.
- Wire it into the Playwright per-test fixture: listeners attach before `page.goto`, and on test failure the buffered text is attached to the test report as `browser-console.log`.
- Wrap `testInfo.attach()` in try/catch so an attachment failure can never mask the original assertion error.
- Vitest unit tests cover the helper (buffering, filtering, page-error formatting with/without stack, toString).

## Why
E2E test failures previously surfaced only the Playwright assertion. The actual cause (system runtime errors, render exceptions, hook failures, schema validation) lived in the browser console and required a manual repro to see. This makes it visible directly in CI output.

## Deferred
- #430 — defensive hardening (size cap, sensitive-logging JSDoc, explicit `page.off(...)` cleanup).

## Test plan
- [x] `npm run quality` clean: 0 lint, 0 type errors, 465 tests pass.
- [x] New unit tests cover helper formatting + buffering edges.
- [ ] CI green on push.