### PR TITLE
Sprint #437: Test infrastructure audit & code quality

### DIFF
--- a/foundry/src/__mocks__/schema-field.test.ts
+++ b/foundry/src/__mocks__/schema-field.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 
 describe("Mock SchemaField validation", () => {
-  it("throws when initial is null without nullable: true", () => {
-    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
-    const { SchemaField } = foundry.data.fields;
+  let SchemaField: (typeof globalThis.foundry.data.fields)["SchemaField"];
 
+  beforeEach(() => {
+    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
+    SchemaField = foundry.data.fields.SchemaField;
+  });
+
+  it("throws when initial is null without nullable: true", () => {
     expect(() => {
       new SchemaField(
         {},
@@ -14,27 +18,18 @@ describe("Mock SchemaField validation", () => {
   });
 
   it("throws when initial is null and nullable is not specified", () => {
-    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
-    const { SchemaField } = foundry.data.fields;
-
     expect(() => {
       new SchemaField({}, { initial: null });
     }).toThrow("initial: null requires nullable: true");
   });
 
   it("accepts initial: null when nullable: true", () => {
-    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
-    const { SchemaField } = foundry.data.fields;
-
     expect(() => {
       new SchemaField({}, { initial: null, nullable: true });
     }).not.toThrow();
   });
 
   it("accepts other initial values without nullable", () => {
-    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
-    const { SchemaField } = foundry.data.fields;
-
     expect(() => {
       new SchemaField({}, { initial: "default", nullable: false });
     }).not.toThrow();

--- a/foundry/src/__mocks__/schema-field.test.ts
+++ b/foundry/src/__mocks__/schema-field.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+describe("Mock SchemaField validation", () => {
+  it("throws when initial is null without nullable: true", () => {
+    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
+    const { SchemaField } = foundry.data.fields;
+
+    expect(() => {
+      new SchemaField(
+        {},
+        { initial: null, nullable: false },
+      );
+    }).toThrow("initial: null requires nullable: true");
+  });
+
+  it("throws when initial is null and nullable is not specified", () => {
+    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
+    const { SchemaField } = foundry.data.fields;
+
+    expect(() => {
+      new SchemaField({}, { initial: null });
+    }).toThrow("initial: null requires nullable: true");
+  });
+
+  it("accepts initial: null when nullable: true", () => {
+    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
+    const { SchemaField } = foundry.data.fields;
+
+    expect(() => {
+      new SchemaField({}, { initial: null, nullable: true });
+    }).not.toThrow();
+  });
+
+  it("accepts other initial values without nullable", () => {
+    const { foundry } = globalThis as unknown as { foundry: typeof global.foundry };
+    const { SchemaField } = foundry.data.fields;
+
+    expect(() => {
+      new SchemaField({}, { initial: "default", nullable: false });
+    }).not.toThrow();
+
+    expect(() => {
+      new SchemaField({}, { initial: 0, nullable: false });
+    }).not.toThrow();
+  });
+});

--- a/foundry/src/__mocks__/setup.ts
+++ b/foundry/src/__mocks__/setup.ts
@@ -230,6 +230,10 @@ Object.assign(globalThis, {
               if (opts.required !== undefined) this.required = opts.required;
               if (opts.nullable !== undefined) this.nullable = opts.nullable;
               if (opts.initial !== undefined) this.initial = opts.initial;
+              // Foundry V13 constraint: initial: null requires nullable: true
+              if (opts.initial === null && !opts.nullable) {
+                throw new Error("initial: null requires nullable: true");
+              }
             }
           }
         },

--- a/foundry/src/__tests__/e2e/console-capture.test.ts
+++ b/foundry/src/__tests__/e2e/console-capture.test.ts
@@ -25,6 +25,18 @@ describe("ConsoleBuffer", () => {
       const lastLine = buffer.lines[buffer.lines.length - 1];
       expect(lastLine).toMatch(/\[truncated.*more entries\]/);
     });
+
+    it("does not add truncation marker at exactly MAX_ENTRIES", () => {
+      const buffer = new ConsoleBuffer();
+
+      for (let i = 0; i < 500; i++) {
+        buffer.recordConsole("error", `Entry ${i}`);
+      }
+
+      expect(buffer.lines.length).toBe(500);
+      const lastLine = buffer.lines[buffer.lines.length - 1];
+      expect(lastLine).not.toMatch(/\[truncated/);
+    });
   });
 
   describe("logging documentation", () => {

--- a/foundry/src/__tests__/e2e/console-capture.test.ts
+++ b/foundry/src/__tests__/e2e/console-capture.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { ConsoleBuffer, formatConsoleEntry, formatPageError } from "./console-capture";
+
+describe("ConsoleBuffer", () => {
+  describe("buffer cap", () => {
+    it("respects MAX_ENTRIES limit", () => {
+      const buffer = new ConsoleBuffer();
+
+      // Record 600 entries (exceeds limit)
+      for (let i = 0; i < 600; i++) {
+        buffer.recordConsole("error", `Entry ${i}`);
+      }
+
+      // Should not exceed max
+      expect(buffer.lines.length).toBeLessThanOrEqual(500);
+    });
+
+    it("appends truncation marker when exceeding limit", () => {
+      const buffer = new ConsoleBuffer();
+
+      for (let i = 0; i < 600; i++) {
+        buffer.recordConsole("error", `Entry ${i}`);
+      }
+
+      const lastLine = buffer.lines[buffer.lines.length - 1];
+      expect(lastLine).toMatch(/\[truncated.*more entries\]/);
+    });
+  });
+
+  describe("logging documentation", () => {
+    it("has JSDoc warning about sensitive data", () => {
+      // This test verifies that ConsoleBuffer has JSDoc documentation
+      // warning callers not to log secrets to the browser console.
+      const buffer = new ConsoleBuffer();
+      expect(buffer).toBeDefined();
+      // The actual check is code-review time: JSDoc must be present
+    });
+  });
+
+  describe("toString() and sensitive data", () => {
+    it("documents that toString() output is attached verbatim to test reports", () => {
+      const buffer = new ConsoleBuffer();
+      buffer.recordConsole("error", "sample message");
+      const output = buffer.toString();
+      expect(output).toContain("[error] sample message");
+    });
+  });
+});
+
+describe("formatConsoleEntry", () => {
+  it("formats console entry with type prefix", () => {
+    expect(formatConsoleEntry("error", "message")).toBe("[error] message");
+    expect(formatConsoleEntry("warning", "caution")).toBe("[warning] caution");
+  });
+});
+
+describe("formatPageError", () => {
+  it("formats error with stack trace", () => {
+    const err = new Error("test error");
+    err.stack = "Error: test error\n  at line1\n  at line2";
+    const result = formatPageError(err);
+    expect(result).toContain("[pageerror] test error");
+    expect(result).toContain("at line1");
+    expect(result).toContain("at line2");
+  });
+
+  it("formats error without stack trace", () => {
+    const err = new Error("test error");
+    delete err.stack;
+    const result = formatPageError(err);
+    expect(result).toBe("[pageerror] test error");
+  });
+});

--- a/foundry/src/__tests__/e2e/console-capture.ts
+++ b/foundry/src/__tests__/e2e/console-capture.ts
@@ -51,7 +51,7 @@ export class ConsoleBuffer {
   #enforceCapacity(): void {
     if (this.entries.length > MAX_ENTRIES) {
       const excess = this.entries.length - MAX_ENTRIES;
-      this.entries.splice(0, excess);
+      this.entries.splice(0, excess + 1);
       this.entries.unshift(`[truncated ${excess} more entries]`);
     }
   }

--- a/foundry/src/__tests__/e2e/console-capture.ts
+++ b/foundry/src/__tests__/e2e/console-capture.ts
@@ -6,9 +6,14 @@
  *
  * Kept in a standalone module so the formatting/buffering logic can be
  * unit-tested without spinning up Playwright or a Foundry server.
+ *
+ * WARNING: toString() output is attached verbatim to Playwright test reports.
+ * Do not log secrets (API keys, passwords, tokens) to the browser console,
+ * as they will be captured and stored in the test report.
  */
 
 const CAPTURED_CONSOLE_TYPES: ReadonlySet<string> = new Set(["error", "warning"]);
+const MAX_ENTRIES = 500;
 
 export function formatConsoleEntry(type: string, text: string): string {
   return `[${type}] ${text}`;
@@ -35,10 +40,20 @@ export class ConsoleBuffer {
   recordConsole(type: string, text: string): void {
     if (!CAPTURED_CONSOLE_TYPES.has(type)) return;
     this.entries.push(formatConsoleEntry(type, text));
+    this.#enforceCapacity();
   }
 
   recordPageError(err: Error): void {
     this.entries.push(formatPageError(err));
+    this.#enforceCapacity();
+  }
+
+  #enforceCapacity(): void {
+    if (this.entries.length > MAX_ENTRIES) {
+      const excess = this.entries.length - MAX_ENTRIES;
+      this.entries.splice(0, excess);
+      this.entries.unshift(`[truncated ${excess} more entries]`);
+    }
   }
 
   toString(): string {

--- a/foundry/src/__tests__/e2e/fixtures.ts
+++ b/foundry/src/__tests__/e2e/fixtures.ts
@@ -63,12 +63,15 @@ export const test = base.extend({
   page: async ({ page }, use, testInfo) => {
     const consoleBuffer = new ConsoleBuffer();
 
-    page.on("console", (msg) => {
+    const consoleHandler = (msg: { type: () => string; text: () => string }) => {
       consoleBuffer.recordConsole(msg.type(), msg.text());
-    });
-    page.on("pageerror", (err) => {
+    };
+    const errorHandler = (err: Error) => {
       consoleBuffer.recordPageError(err);
-    });
+    };
+
+    page.on("console", consoleHandler);
+    page.on("pageerror", errorHandler);
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
 
@@ -89,6 +92,12 @@ export const test = base.extend({
     await openFranchiseSheet(page);
 
     await use(page);
+
+    // Explicit listener cleanup to prevent stale handlers on test retry.
+    // Playwright closes the BrowserContext between tests, but retained listeners
+    // can theoretically fire on reused page objects during retry scenarios.
+    page.off("console", consoleHandler);
+    page.off("pageerror", errorHandler);
 
     if (testInfo.status !== testInfo.expectedStatus && !consoleBuffer.isEmpty()) {
       try {


### PR DESCRIPTION
## Summary

- Enforce `initial: null` requires `nullable: true` in mock `SchemaField` — catches Foundry V13 constraint violations in tests before they fail at runtime (#434)
- Cap `ConsoleBuffer` at 500 entries with truncation marker; add JSDoc warning about secrets in test reports (#430)
- Fix off-by-one in `ConsoleBuffer#enforceCapacity`: was leaving buffer at MAX_ENTRIES+1; now correctly caps at MAX_ENTRIES
- Explicit `page.off()` listener cleanup in Playwright fixture — prevents stale handlers on test retry (#430)
- Add edge-case test: buffer at exactly MAX_ENTRIES does not add a truncation marker
- Extract repeated `globalThis` cast boilerplate to `beforeEach` in `schema-field.test.ts`

## Codebase audit (#432)

Audit complete. 7 findings filed as separate issues:
- #440 P0 bug: stress roll atomicity (Cool deducted before death outcome stored)
- #441 P1 bug: "returned" recovery status not shown in sheet banner
- #442 P1 bug: penalty dialog null return silently skips penalty recording
- #443 P1 bug: `_preUpdate` validation skips when only penalty field changes
- #444 P1 refactor: duplicate `RollActor` interface in two files
- #445 P1 refactor: chained unknown cast for FilePicker needs type definition
- #446 P2 chore: `SKILL_NAMES` exported but only used internally

## Test plan

- [x] `npm run quality` passes (lint + types + 534 tests)
- [x] SchemaField constraint tests: 4 passing
- [x] ConsoleBuffer cap + truncation tests passing
- [x] CI green

Fixes #437
Fixes #430
Fixes #434
Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)