### PR TITLE
fix: SonarQube mechanical remediation + coverage wiring

### DIFF
--- a/.claude/rules/foundry-vite.md
+++ b/.claude/rules/foundry-vite.md
@@ -301,6 +301,18 @@ Add `"verbatimModuleSyntax": true` (required by TS rules). Combined with `"isola
 `allowImportingTsExtensions: true` requires `noEmit: true`.
 `moduleResolution: "bundler"` correct for Vite.
 
+## Deprecated Global APIs (V13)
+
+Foundry V13 moved several globals into namespaces. Use the namespaced forms:
+
+| Deprecated global | Replacement |
+|---|---|
+| `renderTemplate(path, data)` | `foundry.applications.handlebars.renderTemplate(path, data)` |
+| `loadTemplates(paths)` | `foundry.applications.handlebars.loadTemplates(paths)` |
+| `Dialog.wait(config)` | `foundry.applications.api.DialogV2.wait(config)` |
+
+When migrating, update `src/types/foundry-v2.d.ts` if the namespaced function is not yet typed in fvtt-types. Update test mocks to target `foundry.applications.handlebars.renderTemplate` instead of the global.
+
 ## Anti-Patterns
 
 | Never | Use |
@@ -322,3 +334,6 @@ Add `"verbatimModuleSyntax": true` (required by TS rules). Combined with `"isola
 | `extends Application` (V1) | `ApplicationV2` |
 | `getData()` in V2 sheets | `_prepareContext()` |
 | `activateListeners(html: JQuery)` in V2 | `_onRender()` + actions |
+| Global `renderTemplate(...)` | `foundry.applications.handlebars.renderTemplate(...)` |
+| Global `loadTemplates(...)` | `foundry.applications.handlebars.loadTemplates(...)` |
+| Mock `globalThis.renderTemplate` in tests | Mock `foundry.applications.handlebars.renderTemplate` |

--- a/.claude/rules/foundry-vite.md
+++ b/.claude/rules/foundry-vite.md
@@ -303,15 +303,15 @@ Add `"verbatimModuleSyntax": true` (required by TS rules). Combined with `"isola
 
 ## Deprecated Global APIs (V13)
 
-Foundry V13 moved several globals into namespaces. Use the namespaced forms:
+Globals moved to namespaces in V13:
 
-| Deprecated global | Replacement |
+| Deprecated | Use |
 |---|---|
 | `renderTemplate(path, data)` | `foundry.applications.handlebars.renderTemplate(path, data)` |
 | `loadTemplates(paths)` | `foundry.applications.handlebars.loadTemplates(paths)` |
 | `Dialog.wait(config)` | `foundry.applications.api.DialogV2.wait(config)` |
 
-When migrating, update `src/types/foundry-v2.d.ts` if the namespaced function is not yet typed in fvtt-types. Update test mocks to target `foundry.applications.handlebars.renderTemplate` instead of the global.
+If namespaced form missing from fvtt-types, add to `src/types/foundry-v2.d.ts`. Update test mocks to target `foundry.applications.handlebars.renderTemplate` not the global.
 
 ## Anti-Patterns
 

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -153,12 +153,13 @@ Always `const` or `let`. Default to `const`. No `var`.
 
 - Minimize exported surface
 - Never write `public` explicitly (it's default; exception: non-readonly constructor params)
-- Use `readonly` on non-reassigned properties
+- Use `readonly` on **every** property not reassigned after construction — including `static` overrides (`static override readonly DEFAULT_OPTIONS`)
 - Use parameter properties to avoid boilerplate
 - Initialize fields at declaration when possible
 - No `#private`. Use TypeScript `private` (better size/perf)
 - Getters pure (no side effects)
 - No arrow-function properties unless need stable `this` for unregistration
+- No empty constructors — delete them; JS provides a default
 
 ## Functions
 
@@ -188,6 +189,8 @@ const POLL_TIMEOUT_MS = 30_000; // 30s = server-side request timeout
 - String: `String(x)` or template literals. No `"" + x`
 - Number: `Number(x)` then check `isNaN`. No unary `+`. `parseInt` only non-base-10
 - Boolean: implicit truthiness in conditionals. No `!!x`. Explicit comparisons (`arr.length > 0`) fine
+- **`Number.isNaN` not `isNaN`** — `isNaN` coerces to number first (`isNaN("abc")` is `true`); `Number.isNaN` is precise
+- **Template literal interpolation** — always `${String(x)}` when `x` is `unknown` or could be an object; bare `${x}` produces `[object Object]` for File/FormData/any non-primitive
 
 ## Spread
 
@@ -202,6 +205,57 @@ const POLL_TIMEOUT_MS = 30_000; // 30s = server-side request timeout
 - Mock boundaries only (network, filesystem, external)
 - Colocate tests (`*.test.ts` next to source)
 - Use `vitest`
+
+## Null-coalescing and optional chaining
+
+Prefer compact, idiomatic forms over verbose conditionals:
+
+```typescript
+// ??= for lazy initialization
+loggerInstance ??= new DevLogger();       // not: if (!loggerInstance) loggerInstance = new DevLogger()
+hookHandlers[event] ??= [];               // not: if (!hookHandlers[event]) hookHandlers[event] = []
+
+// Optional chain to simplify guarded access
+if (!element?.isConnected) ...            // not: if (!element || !element.isConnected)
+const match = key.match(/pat/);
+if (match?.[1] && match[2]) ...           // not: if (match && match[1] && match[2])
+```
+
+## Element attributes
+
+Prefer `.dataset` over `getAttribute("data-*")`:
+
+```typescript
+const rollType = target.dataset["rollType"] ?? null;   // not: target.getAttribute("data-roll-type")
+```
+
+`dataset` avoids the `data-` prefix, is camelCase-normalized, and returns `undefined` instead of `null`.
+
+## Throw types
+
+Throw `TypeError` for type/value validation failures (wrong shape, unexpected type), `Error` for logic/state failures:
+
+```typescript
+if (typeof input !== "string") throw new TypeError("Expected string, got " + typeof input);
+if (!scene.exists) throw new Error("Scene not found: " + id);
+```
+
+## Re-exports
+
+Use `export ... from` to re-export symbols (avoids import+export duplication):
+
+```typescript
+export { expect } from "@playwright/test";   // not: import { expect } from ...; export { expect };
+```
+
+## Node built-in imports
+
+Always use `node:` prefix for built-in modules:
+
+```typescript
+import fs from "node:fs";     // not: import fs from "fs"
+import path from "node:path"; // not: import path from "path"
+```
 
 ## Anti-Patterns
 
@@ -224,3 +278,11 @@ const POLL_TIMEOUT_MS = 30_000; // 30s = server-side request timeout
 | `debugger` | Remove before commit |
 | Empty `catch {}` | Handle or rethrow |
 | `console.log` in production | Structured logging |
+| `isNaN(x)` | `Number.isNaN(x)` |
+| `${unknownValue}` in template literals | `${String(unknownValue)}` when type is unknown/object |
+| `if (!x) x = y` | `x ??= y` |
+| `import fs from "fs"` | `import fs from "node:fs"` |
+| `target.getAttribute("data-foo")` | `target.dataset["foo"]` |
+| `throw new Error(...)` for type errors | `throw new TypeError(...)` |
+| Empty constructor `constructor() {}` | Delete it (JS default) |
+| `static override PARTS = ...` (non-readonly) | `static override readonly PARTS = ...` |

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -189,8 +189,8 @@ const POLL_TIMEOUT_MS = 30_000; // 30s = server-side request timeout
 - String: `String(x)` or template literals. No `"" + x`
 - Number: `Number(x)` then check `isNaN`. No unary `+`. `parseInt` only non-base-10
 - Boolean: implicit truthiness in conditionals. No `!!x`. Explicit comparisons (`arr.length > 0`) fine
-- **`Number.isNaN` not `isNaN`** — `isNaN` coerces to number first (`isNaN("abc")` is `true`); `Number.isNaN` is precise
-- **Template literal interpolation** — always `${String(x)}` when `x` is `unknown` or could be an object; bare `${x}` produces `[object Object]` for File/FormData/any non-primitive
+- **`Number.isNaN` not `isNaN`** — `isNaN` coerces first (`isNaN("abc")` = `true`); `Number.isNaN` precise
+- **Template literal interpolation** — `${String(x)}` when `x` is `unknown` or object; bare `${x}` → `[object Object]` for File/FormData/non-primitives
 
 ## Spread
 
@@ -208,14 +208,12 @@ const POLL_TIMEOUT_MS = 30_000; // 30s = server-side request timeout
 
 ## Null-coalescing and optional chaining
 
-Prefer compact, idiomatic forms over verbose conditionals:
-
 ```typescript
-// ??= for lazy initialization
+// ??= for lazy init
 loggerInstance ??= new DevLogger();       // not: if (!loggerInstance) loggerInstance = new DevLogger()
 hookHandlers[event] ??= [];               // not: if (!hookHandlers[event]) hookHandlers[event] = []
 
-// Optional chain to simplify guarded access
+// Optional chain
 if (!element?.isConnected) ...            // not: if (!element || !element.isConnected)
 const match = key.match(/pat/);
 if (match?.[1] && match[2]) ...           // not: if (match && match[1] && match[2])
@@ -223,17 +221,15 @@ if (match?.[1] && match[2]) ...           // not: if (match && match[1] && match
 
 ## Element attributes
 
-Prefer `.dataset` over `getAttribute("data-*")`:
+`.dataset` over `getAttribute("data-*")` — no `data-` prefix, camelCase-normalized, returns `undefined` not `null`:
 
 ```typescript
 const rollType = target.dataset["rollType"] ?? null;   // not: target.getAttribute("data-roll-type")
 ```
 
-`dataset` avoids the `data-` prefix, is camelCase-normalized, and returns `undefined` instead of `null`.
-
 ## Throw types
 
-Throw `TypeError` for type/value validation failures (wrong shape, unexpected type), `Error` for logic/state failures:
+`TypeError` for type/value failures; `Error` for logic/state failures:
 
 ```typescript
 if (typeof input !== "string") throw new TypeError("Expected string, got " + typeof input);
@@ -242,19 +238,17 @@ if (!scene.exists) throw new Error("Scene not found: " + id);
 
 ## Re-exports
 
-Use `export ... from` to re-export symbols (avoids import+export duplication):
-
 ```typescript
 export { expect } from "@playwright/test";   // not: import { expect } from ...; export { expect };
 ```
 
 ## Node built-in imports
 
-Always use `node:` prefix for built-in modules:
+Always `node:` prefix:
 
 ```typescript
-import fs from "node:fs";     // not: import fs from "fs"
-import path from "node:path"; // not: import path from "path"
+import fs from "node:fs";
+import path from "node:path";
 ```
 
 ## Anti-Patterns

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,27 +262,3 @@ jobs:
           path: foundry/coverage/lcov.info
           if-no-files-found: error
 
-  sonar:
-    name: SonarQube analysis
-    runs-on: ubuntu-latest
-    needs: [unit-test]
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Download coverage artifact
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
-        with:
-          name: coverage-lcov
-          path: foundry/coverage/
-
-      - name: SonarQube scan
-        uses: sonarsource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d  # v5.0.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,27 @@ jobs:
         working-directory: foundry
         run: npm ci
 
+      - name: Cache apt packages (Playwright fonts + X deps)
+        id: apt-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+        with:
+          path: /var/cache/apt/archives
+          key: apt-playwright-chromium-${{ runner.os }}-v1
+
+      - name: Install apt dependencies for Playwright
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            fonts-freefont-ttf \
+            fonts-ipafont-gothic \
+            fonts-tlwg-loma-otf \
+            fonts-unifont \
+            fonts-wqy-zenhei \
+            xfonts-cyrillic \
+            xfonts-encodings \
+            xfonts-scalable \
+            xfonts-utils
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
@@ -183,15 +204,27 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('foundry/package-lock.json') }}-${{ runner.os }}
 
-      - name: Install Playwright browsers (full, cache miss)
+      - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: foundry
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
-      - name: Install Playwright system deps (cache hit)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        working-directory: foundry
-        run: npx playwright install-deps chromium
+      - name: Cache Foundry Docker image
+        id: foundry-image-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
+        with:
+          path: /tmp/foundry-image.tar
+          key: docker-foundry-v13-${{ runner.os }}-v1
+
+      - name: Load Foundry image from cache
+        if: steps.foundry-image-cache.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/foundry-image.tar
+
+      - name: Pull Foundry image and save to cache
+        if: steps.foundry-image-cache.outputs.cache-hit != 'true'
+        run: |
+          docker pull ghcr.io/felddy/foundryvtt:13
+          docker save ghcr.io/felddy/foundryvtt:13 -o /tmp/foundry-image.tar
 
       - name: Start Foundry container
         working-directory: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
   e2e:
     name: E2E tests
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, unit-test, typecheck]
     permissions:
       contents: read
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,3 +228,61 @@ jobs:
           path: |
             foundry/playwright-report/
             foundry/test-results/
+
+  unit-test:
+    name: Unit tests + coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: foundry/package-lock.json
+
+      - name: Install dependencies
+        working-directory: foundry
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        working-directory: foundry
+        run: npm run test -- --coverage
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coverage-lcov
+          path: foundry/coverage/lcov.info
+          if-no-files-found: error
+
+  sonar:
+    name: SonarQube analysis
+    runs-on: ubuntu-latest
+    needs: [unit-test]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
+        with:
+          name: coverage-lcov
+          path: foundry/coverage/
+
+      - name: SonarQube scan
+        uses: sonarsource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d  # v5.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -14,6 +14,9 @@
 
 /* ============================================================
    PALETTE — InSpectres tokens (mirrors foundry/src/styles/theme/variables.css)
+   INFIMA OVERRIDES — Light mode
+   Primary = green-dark; success = green-dark; danger = #c41e3a; warning = orange
+   Steps follow Infima's convention: darkest → light progression.
    ============================================================ */
 :root {
   --inspectres-green-dark: #38b44a;
@@ -29,14 +32,7 @@
   --inspectres-danger: #c41e3a;
   --inspectres-white: #ffffff;
   --inspectres-black: #000000;
-}
 
-/* ============================================================
-   INFIMA OVERRIDES — Light mode
-   Primary = green-dark; success = green-dark; danger = #c41e3a; warning = orange
-   Steps follow Infima's convention: darkest → light progression.
-   ============================================================ */
-:root {
   --ifm-color-primary: #38b44a;
   --ifm-color-primary-dark: #2d9e3f;
   --ifm-color-primary-darker: #2a953b;

--- a/foundry/src/__mocks__/setup.ts
+++ b/foundry/src/__mocks__/setup.ts
@@ -18,7 +18,7 @@ class MockActorSheetV2 {
   actor: MockActor = new MockActor();
   isEditable: boolean = true;
 
-  static DEFAULT_OPTIONS = {
+  static readonly DEFAULT_OPTIONS = {
     id: "",
     classes: [] as string[],
     window: { title: "" },
@@ -26,7 +26,7 @@ class MockActorSheetV2 {
     actions: {} as Record<string, unknown>,
   };
 
-  static PARTS: Record<string, { template: string }> = {};
+  static readonly PARTS: Record<string, { template: string }> = {};
 
   async _prepareContext(_options: unknown) {
     return {
@@ -44,7 +44,7 @@ class MockActorSheetV2 {
 
 // Mock ApplicationV2 class
 class MockApplicationV2 {
-  static DEFAULT_OPTIONS = {
+  static readonly DEFAULT_OPTIONS = {
     id: "",
     classes: [] as string[],
     window: { title: "" },
@@ -60,11 +60,11 @@ const hookHandlers: Record<string, Function[]> = {};
 
 const Hooks = {
   once(event: string, fn: Function) {
-    if (!hookHandlers[event]) hookHandlers[event] = [];
+    hookHandlers[event] ??= [];
     hookHandlers[event].push(fn);
   },
   on(event: string, fn: Function) {
-    if (!hookHandlers[event]) hookHandlers[event] = [];
+    hookHandlers[event] ??= [];
     hookHandlers[event].push(fn);
   },
   call(event: string, ...args: unknown[]) {
@@ -191,8 +191,8 @@ async function renderTemplate(_path: string, data: unknown): Promise<string> {
 }
 
 // Mock loadTemplates
-async function loadTemplates(paths: string[]): Promise<void> {
-  void paths;
+async function loadTemplates(_paths: string[]): Promise<void> {
+  // stub
 }
 
 // Assign to global
@@ -215,10 +215,10 @@ Object.assign(globalThis, {
     },
     data: {
       fields: {
-        StringField: class { constructor(_opts?: unknown) {} },
-        NumberField: class { constructor(_opts?: unknown) {} },
-        BooleanField: class { constructor(_opts?: unknown) {} },
-        ArrayField: class { constructor(_element?: unknown, _opts?: unknown) {} },
+        StringField: class {},
+        NumberField: class {},
+        BooleanField: class {},
+        ArrayField: class {},
         SchemaField: class {
           fields: Record<string, unknown>;
           required?: boolean;
@@ -250,6 +250,10 @@ Object.assign(globalThis, {
         DialogV2: MockDialogV2,
         // Identity mixin — returns the base class unchanged so sheet class definitions type-check
         HandlebarsApplicationMixin: <T>(Base: T): T => Base,
+      },
+      handlebars: {
+        renderTemplate: renderTemplate,
+        loadTemplates: loadTemplates,
       },
       sheets: {
         ActorSheetV2: MockActorSheetV2,

--- a/foundry/src/__tests__/accessibility/axe-setup.ts
+++ b/foundry/src/__tests__/accessibility/axe-setup.ts
@@ -50,13 +50,13 @@ export function expectContrastCompliant(
   element: HTMLElement | null | undefined,
   minRatio: number = 4.5,
 ): void {
-  if (!element || !element.isConnected) {
-    throw new Error(`Element not connected to DOM: ${element?.tagName ?? "unknown"}`);
+  if (!element?.isConnected) {
+    throw new TypeError(`Element not connected to DOM: ${element?.tagName ?? "unknown"}`);
   }
 
   const styles = globalThis.getComputedStyle(element);
   if (!styles) {
-    throw new Error(`Failed to retrieve computed styles for ${element.tagName}`);
+    throw new TypeError(`Failed to retrieve computed styles for ${element.tagName}`);
   }
 
   const color = styles.color;

--- a/foundry/src/__tests__/e2e/fixtures.ts
+++ b/foundry/src/__tests__/e2e/fixtures.ts
@@ -1,4 +1,6 @@
-import { test as base, expect, type Page } from "@playwright/test";
+import { test as base, type Page } from "@playwright/test";
+export { expect } from "@playwright/test";
+
 import { ConsoleBuffer } from "./console-capture";
 import { workerStorageStatePath, workerUsername, E2E_VIEWPORT, WORKER_COUNT } from "./global-setup.js";
 
@@ -195,4 +197,3 @@ export const test = base.extend({
   },
 });
 
-export { expect };

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -322,7 +322,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
 
   static async onRemoveCharacteristic(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    const idxStr = target.dataset["idx"];
+    const idxStr = target.dataset["idx"] ?? null;
     if (idxStr == null) {
       console.error("onRemoveCharacteristic: missing data-idx attribute");
       return;

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -77,8 +77,8 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
           const stressDiceCount = Math.max(1, Math.min(5, Number(data.get("stressDice") ?? 1)));
           const coolDiceUsed = Math.max(0, Math.min(maxCool, Number(data.get("coolIgnore") ?? 0)));
           return {
-            stressDiceCount: isNaN(stressDiceCount) ? 1 : stressDiceCount,
-            coolDiceUsed: isNaN(coolDiceUsed) ? 0 : coolDiceUsed,
+            stressDiceCount: Number.isNaN(stressDiceCount) ? 1 : stressDiceCount,
+            coolDiceUsed: Number.isNaN(coolDiceUsed) ? 0 : coolDiceUsed,
           };
         },
       },
@@ -99,7 +99,7 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
 // HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
 export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
 
-  static override DEFAULT_OPTIONS = {
+  static override readonly DEFAULT_OPTIONS = {
     classes: ["inspectres", "sheet", "actor", "agent"],
     position: { width: 600, height: 700 as number | "auto" },
     form: { submitOnChange: true, closeOnSubmit: false },
@@ -121,7 +121,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     },
   };
 
-  static override PARTS = {
+  static override readonly PARTS = {
     sheet: { template: "systems/inspectres/templates/agent-sheet.hbs" },
   };
 
@@ -200,7 +200,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
   }
 
   static async onSkillRoll(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
-    const skillAttr = target.getAttribute("data-skill");
+    const skillAttr = target.dataset["skill"] ?? null;
     if (!isSkillName(skillAttr)) {
       console.error("onSkillRoll: missing or invalid data-skill attribute", { skillAttr });
       return;
@@ -250,7 +250,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
 
   static async onSkillStep(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    const skillAttr = target.getAttribute("data-skill");
+    const skillAttr = target.dataset["skill"] ?? null;
     if (!isSkillName(skillAttr)) {
       console.error("onSkillStep: missing or invalid data-skill attribute", { skillAttr });
       return;
@@ -267,7 +267,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
       return;
     }
     const current = skillData.base;
-    const delta = target.getAttribute("data-action") === "skillIncrease" ? 1 : -1;
+    const delta = target.dataset["action"] === "skillIncrease" ? 1 : -1;
     const next = Math.min(4, Math.max(0, current + delta));
     if (next === current) return;
     // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
@@ -279,7 +279,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
 
   static async onToggleCool(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    const valueStr = target.getAttribute("data-value");
+    const valueStr = target.dataset["value"];
     if (valueStr == null) {
       console.error("onToggleCool: missing data-value attribute");
       return;
@@ -312,7 +312,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnActionBlockedRecovery") ?? "Cannot act while recovering");
       return;
     }
-    const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
+    const characteristics = currentSystem.characteristics ?? [];
     // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
     const updateData = { "system.characteristics": [...characteristics, { text: "", used: false }] } as unknown as Parameters<typeof this.actor.update>[0];
     void this.actor.update(updateData).catch((err: unknown) => {
@@ -322,7 +322,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
 
   static async onRemoveCharacteristic(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    const idxStr = target.getAttribute("data-idx");
+    const idxStr = target.dataset["idx"];
     if (idxStr == null) {
       console.error("onRemoveCharacteristic: missing data-idx attribute");
       return;
@@ -338,7 +338,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnActionBlockedRecovery") ?? "Cannot act while recovering");
       return;
     }
-    const characteristics = (currentSystem.characteristics ?? []) as AgentCharacteristic[];
+    const characteristics = currentSystem.characteristics ?? [];
     // fvtt-types expects full document data shape for actor.update; partial update path is safe at runtime
     const updateData = { "system.characteristics": characteristics.filter((_: AgentCharacteristic, i: number) => i !== idx) } as unknown as Parameters<typeof this.actor.update>[0];
     void this.actor.update(updateData).catch((err: unknown) => {
@@ -356,7 +356,8 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     }
     const type = target.dataset["type"] ?? "image";
     const current = this.actor.img ?? undefined;
-    const FilePicker = (foundry.applications.api as unknown as { FilePicker: unknown }).FilePicker as unknown as { new (options: { current?: string | undefined; type: string; callback?: (path: string) => void }): { browse(): void } };
+    type FilePickerCtor = new (options: { current?: string | undefined; type: string; callback?: ((path: string) => void) | undefined }) => { browse(): void };
+    const FilePicker = (foundry.applications.api as unknown as { FilePicker: unknown }).FilePicker as unknown as FilePickerCtor;
     const picker = new FilePicker({
       current,
       type,
@@ -503,7 +504,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
             const form = dialog.querySelector("form") as HTMLFormElement | null;
             if (!form) return null;
             const days = Math.max(1, Math.min(10, Number(new FormData(form).get("days") ?? 2)));
-            return { days: isNaN(days) ? 2 : days };
+            return { days: Number.isNaN(days) ? 2 : days };
           },
         },
         { action: "cancel", label: i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel" },
@@ -534,7 +535,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     const input = target as HTMLInputElement;
     const targetDay = Number(input.value);
     const MAX_RECOVERY_DAY = 365;
-    if (!Number.isInteger(targetDay) || isNaN(targetDay) || targetDay < 1 || targetDay > MAX_RECOVERY_DAY) {
+    if (!Number.isInteger(targetDay) || Number.isNaN(targetDay) || targetDay < 1 || targetDay > MAX_RECOVERY_DAY) {
       ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnInvalidDay") ?? "Invalid day number");
       return;
     }
@@ -562,7 +563,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
 
   static async onRestoreSkill(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
     if (!this.isEditable) return;
-    const skillAttr = target.getAttribute("data-skill");
+    const skillAttr = target.dataset["skill"] ?? null;
     if (!isSkillName(skillAttr)) {
       console.error("onRestoreSkill: missing or invalid data-skill attribute", { skillAttr });
       return;
@@ -596,7 +597,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
             const form = dialog.querySelector("form") as HTMLFormElement | null;
             if (!form) return null;
             const cool = Math.max(1, Math.min(maxCool, Number(new FormData(form).get("cool") ?? 1)));
-            return { cool: isNaN(cool) ? 1 : cool };
+            return { cool: Number.isNaN(cool) ? 1 : cool };
           },
         },
         { action: "cancel", label: i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel" },

--- a/foundry/src/agent/InSpectresAgent.ts
+++ b/foundry/src/agent/InSpectresAgent.ts
@@ -140,7 +140,7 @@ export class InSpectresAgent extends Actor {
       for (const [key, value] of Object.entries(systemChanges)) {
         if (key.startsWith("skills.")) {
           const match = key.match(/^skills\.(\w+)\.(\w+)$/);
-          if (match && match[1] && match[2]) {
+          if (match?.[1] && match[2]) {
             const skillName = match[1];
             const fieldName = match[2];
             if (skillName in mergedSkills) {

--- a/foundry/src/agent/skill-recovery.ts
+++ b/foundry/src/agent/skill-recovery.ts
@@ -7,7 +7,6 @@
 import { agentSystemData } from "./agent-system-data.js";
 import { computeRecoveryStatus, getCurrentDay } from "./recovery-utils.js";
 import type { SkillName } from "../rolls/roll-executor.js";
-import type { AgentData } from "./agent-schema.js";
 
 export interface SkillRecoveryResult {
   readonly success: boolean;

--- a/foundry/src/agent/vacation-dialog.ts
+++ b/foundry/src/agent/vacation-dialog.ts
@@ -3,8 +3,6 @@
  * Per rules: Bank dice spent on vacation reduce stress by 1 per die, up to current stress
  */
 
-import { type FranchiseData } from "../franchise/franchise-schema.js";
-import { type AgentData } from "./agent-schema.js";
 
 export interface VacationOptions {
   agentStress: number;
@@ -95,7 +93,7 @@ export async function buildVacationDialog(options: VacationOptions): Promise<Vac
           const coolRestoreRaw = Number(data.get("coolRestore") ?? 0);
 
           if (!Number.isFinite(bankSpendRaw) || !Number.isFinite(coolRestoreRaw)) {
-            throw new Error("Invalid input: bank spending must be valid numbers");
+            throw new TypeError("Invalid input: bank spending must be valid numbers");
           }
 
           const bankSpentOnStress = Math.max(0, Math.min(maxStressSpendable, bankSpendRaw));

--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -12,7 +12,7 @@ import { applyEndOfSessionBonuses, initiateBankruptcyRestart } from "./vacation-
 
 // HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
 export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
-  static override DEFAULT_OPTIONS = {
+  static override readonly DEFAULT_OPTIONS = {
     classes: ["inspectres", "sheet", "actor", "franchise"],
     position: { width: 600, height: 600 as number | "auto" },
     form: { submitOnChange: true, closeOnSubmit: false },
@@ -32,7 +32,7 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
     },
   };
 
-  static override PARTS = {
+  static override readonly PARTS = {
     sheet: { template: "systems/inspectres/templates/franchise-sheet.hbs" },
   };
 
@@ -206,7 +206,8 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
       });
 
     const baseMsg = game.i18n?.localize("INSPECTRES.MissionCompleteAnnounce") ?? "The mission is complete! Franchise dice have been distributed.";
-    const content2 = `<p>${baseMsg}</p><ul>${lines.map((l) => `<li>${l}</li>`).join("")}</ul>`;
+    const listItems = lines.map((l) => `<li>${l}</li>`).join("");
+    const content2 = `<p>${baseMsg}</p><ul>${listItems}</ul>`;
     await ChatMessage.create({ content: content2 } as unknown as Parameters<typeof ChatMessage.create>[0]);
   }
 

--- a/foundry/src/franchise/bankruptcy-handler.ts
+++ b/foundry/src/franchise/bankruptcy-handler.ts
@@ -88,7 +88,7 @@ export async function enterDebtMode(franchiseActor: Actor, attemptedSpend: numbe
   await franchiseActor.update(updateData);
 
   ui.notifications?.warn(
-    game.i18n?.localize("INSPECTRES.NotifyDebtEntered") ?? `Franchise entered debt: borrowed ${borrowResult} dice.`,
+    game.i18n?.localize("INSPECTRES.NotifyDebtEntered") ?? `Franchise entered debt: borrowed ${String(borrowResult)} dice.`,
   );
 
   return true;

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -10,9 +10,7 @@ export class MissionTrackerApp extends foundry.applications.api.HandlebarsApplic
   static instance: MissionTrackerApp | null = null;
 
   static open(): void {
-    if (!MissionTrackerApp.instance) {
-      MissionTrackerApp.instance = new MissionTrackerApp();
-    }
+    MissionTrackerApp.instance ??= new MissionTrackerApp();
     const instance = MissionTrackerApp.instance;
     void instance.render({ force: true }).catch((err: unknown) => {
       handleActionError(err, "Failed to open Mission Tracker", "INSPECTRES.ErrorMissionTrackerOpen", "Failed to open Mission Tracker");
@@ -22,7 +20,7 @@ export class MissionTrackerApp extends foundry.applications.api.HandlebarsApplic
     });
   }
 
-  static override DEFAULT_OPTIONS: foundry.applications.api.ApplicationV2Options = {
+  static override readonly DEFAULT_OPTIONS: foundry.applications.api.ApplicationV2Options = {
     id: "inspectres-mission-tracker",
     classes: ["inspectres", "inspectres-mission-tracker-window"],
     window: {
@@ -36,7 +34,7 @@ export class MissionTrackerApp extends foundry.applications.api.HandlebarsApplic
     },
   };
 
-  static override PARTS = {
+  static override readonly PARTS = {
     sheet: { template: "systems/inspectres/templates/mission-tracker.hbs" },
   };
 
@@ -101,13 +99,13 @@ export class MissionTrackerApp extends foundry.applications.api.HandlebarsApplic
     if (distributedTotal !== refreshedTotal) {
       const msg = game.i18n?.format("INSPECTRES.DistributeDialogTotalMismatch", { total: String(refreshedTotal) })
         ?? `Total must equal ${refreshedTotal} dice.`;
-      if (distributedTotal !== total) {
+      if (distributedTotal === total) {
+        ui.notifications?.warn(msg);
+      } else {
         ui.notifications?.warn(
           game.i18n?.localize("INSPECTRES.DistributeDialogPoolChanged")
             ?? `Mission pool changed from ${total} to ${refreshedTotal} while the dialog was open.`,
         );
-      } else {
-        ui.notifications?.warn(msg);
       }
       return;
     }
@@ -137,7 +135,8 @@ export class MissionTrackerApp extends foundry.applications.api.HandlebarsApplic
       });
 
     const baseMsg = game.i18n?.localize("INSPECTRES.MissionCompleteAnnounce") ?? "The mission is complete! Franchise dice have been distributed.";
-    const content = `<p>${baseMsg}</p><ul>${lines.map((l) => `<li>${l}</li>`).join("")}</ul>`;
+    const listItems = lines.map((l) => `<li>${l}</li>`).join("");
+    const content = `<p>${baseMsg}</p><ul>${listItems}</ul>`;
     await ChatMessage.create({ content } as unknown as Parameters<typeof ChatMessage.create>[0]);
 
     if (MissionTrackerApp.instance === this) {

--- a/foundry/src/mission/MissionTrackerApp.ts
+++ b/foundry/src/mission/MissionTrackerApp.ts
@@ -99,14 +99,11 @@ export class MissionTrackerApp extends foundry.applications.api.HandlebarsApplic
     if (distributedTotal !== refreshedTotal) {
       const msg = game.i18n?.format("INSPECTRES.DistributeDialogTotalMismatch", { total: String(refreshedTotal) })
         ?? `Total must equal ${refreshedTotal} dice.`;
-      if (distributedTotal === total) {
-        ui.notifications?.warn(msg);
-      } else {
-        ui.notifications?.warn(
-          game.i18n?.localize("INSPECTRES.DistributeDialogPoolChanged")
-            ?? `Mission pool changed from ${total} to ${refreshedTotal} while the dialog was open.`,
-        );
-      }
+      const warnMsg = distributedTotal === total
+        ? msg
+        : game.i18n?.localize("INSPECTRES.DistributeDialogPoolChanged")
+          ?? `Mission pool changed from ${total} to ${refreshedTotal} while the dialog was open.`;
+      ui.notifications?.warn(warnMsg);
       return;
     }
 

--- a/foundry/src/mission/confessional-ui.ts
+++ b/foundry/src/mission/confessional-ui.ts
@@ -2,7 +2,7 @@ let activeConfessionalSceneId: string | null = null;
 
 function validateSceneId(sceneId: unknown, context: string): asserts sceneId is string {
   if (typeof sceneId !== "string") {
-    throw new Error(`Scene ID required for ${context}: received ${typeof sceneId}`);
+    throw new TypeError(`Scene ID required for ${context}: received ${typeof sceneId}`);
   }
   if (sceneId.trim() === "") {
     throw new Error(`Scene ID cannot be empty for ${context}`);

--- a/foundry/src/rolls/private-life-roll.ts
+++ b/foundry/src/rolls/private-life-roll.ts
@@ -12,7 +12,7 @@ export interface Augmentations {
 
 function validateAugmentationState(state: unknown): asserts state is AugmentationState {
   if (typeof state !== "object" || state === null) {
-    throw new Error("Augmentation state must be an object");
+    throw new TypeError("Augmentation state must be an object");
   }
   const obj = state as Record<string, unknown>;
   if (typeof obj["available"] !== "boolean") {

--- a/foundry/src/rolls/private-life-roll.ts
+++ b/foundry/src/rolls/private-life-roll.ts
@@ -16,10 +16,10 @@ function validateAugmentationState(state: unknown): asserts state is Augmentatio
   }
   const obj = state as Record<string, unknown>;
   if (typeof obj["available"] !== "boolean") {
-    throw new Error("Augmentation state must be boolean for 'available' property");
+    throw new TypeError("Augmentation state must be boolean for 'available' property");
   }
   if (typeof obj["selected"] !== "boolean") {
-    throw new Error("Augmentation state must be boolean for 'selected' property");
+    throw new TypeError("Augmentation state must be boolean for 'selected' property");
   }
 }
 

--- a/foundry/src/rolls/requirements-integration.ts
+++ b/foundry/src/rolls/requirements-integration.ts
@@ -5,13 +5,13 @@ export interface MissionState {
 
 function validateMissionState(mission: unknown): asserts mission is MissionState {
   if (typeof mission !== "object" || mission === null) {
-    throw new Error("Mission state must be an object");
+    throw new TypeError("Mission state must be an object");
   }
   const obj = mission as Record<string, unknown>;
 
   const validRarities = ["common", "rare", "exotic"];
   if (!validRarities.includes(obj["itemRarity"] as string)) {
-    throw new Error("Mission itemRarity must be one of: common, rare, exotic");
+    throw new TypeError("Mission itemRarity must be one of: common, rare, exotic");
   }
 
   if (typeof obj["requirementsMet"] !== "boolean") {

--- a/foundry/src/rolls/requirements-integration.ts
+++ b/foundry/src/rolls/requirements-integration.ts
@@ -15,7 +15,7 @@ function validateMissionState(mission: unknown): asserts mission is MissionState
   }
 
   if (typeof obj["requirementsMet"] !== "boolean") {
-    throw new Error("Mission requirementsMet field must be boolean");
+    throw new TypeError("Mission requirementsMet field must be boolean");
   }
 }
 

--- a/foundry/src/rolls/roll-executor.test.ts
+++ b/foundry/src/rolls/roll-executor.test.ts
@@ -516,7 +516,8 @@ describe("executeClientRoll", () => {
       }
     };
     let capturedContent = "";
-    vi.spyOn(globalThis as unknown as { renderTemplate: (path: string, data: Record<string, unknown>) => Promise<string> }, "renderTemplate")
+    const handlebars = (globalThis as unknown as { foundry: { applications: { handlebars: { renderTemplate: (path: string, data: Record<string, unknown>) => Promise<string> } } } }).foundry.applications.handlebars;
+    vi.spyOn(handlebars, "renderTemplate")
       .mockImplementation(async (_path: string, data: Record<string, unknown>) => {
         capturedContent = JSON.stringify(data);
         return capturedContent;

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -11,7 +11,7 @@ import { type AgentData } from "../agent/agent-schema.js";
 import { agentSystemData } from "../agent/agent-system-data.js";
 import { type FranchiseData } from "../franchise/franchise-schema.js";
 import { emitMissionPoolUpdated } from "../mission/socket.js";
-import { getCurrentDay, computeRecoveryStatus } from "../agent/recovery-utils.js";
+import { getCurrentDay } from "../agent/recovery-utils.js";
 import { type ItemRarity, isRollSufficient, checkDefect } from "../mission/requirements-checker.js";
 import { prepareSkillRollContext, type SkillRollContextInput } from "../agent/skill-roll-dialog.js";
 import { checkTechnologyRollRequirements } from "./skill-roll-executor.js";
@@ -23,6 +23,7 @@ import { checkTechnologyRollRequirements } from "./skill-roll-executor.js";
 export type SkillName = "academics" | "athletics" | "technology" | "contact";
 
 export type RollType = "skill" | "bank" | "stress" | "client";
+type D3Result = 1 | 2 | 3;
 
 type DieFace = 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -369,7 +370,7 @@ export async function executeSkillRoll(
 
   // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: agent as Actor });
-  const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
+  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "skill",
     title: `${game.i18n?.localize("INSPECTRES.SkillRoll") ?? "Skill Roll"}: ${skillName}`,
     result: outcome.result,
@@ -487,7 +488,8 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
           const coolDice = Math.min(Number(data.get("coolDice") ?? 0), opts.availableCool);
           const talentDie = data.has("talentDie");
           const takesFour = data.has("takesFour");
-          const requirementTierRaw = String(data.get("requirementTier") ?? "");
+          const requirementTierEntry = data.get("requirementTier");
+          const requirementTierRaw = typeof requirementTierEntry === "string" ? requirementTierEntry : "";
           const requirementTier = (requirementTierRaw === "common" || requirementTierRaw === "rare" || requirementTierRaw === "exotic")
             ? requirementTierRaw
             : undefined;
@@ -498,8 +500,8 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
           }
           return {
             cardDice,
-            bankDice: isNaN(bankDice) ? 0 : bankDice,
-            coolDice: isNaN(coolDice) ? 0 : coolDice,
+            bankDice: Number.isNaN(bankDice) ? 0 : bankDice,
+            coolDice: Number.isNaN(coolDice) ? 0 : coolDice,
             talentDie,
             takesFour,
             requirementTier,
@@ -538,7 +540,7 @@ export async function executeBankRoll(franchise: RollActor): Promise<void> {
 
   // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
-  const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
+  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "bank",
     title: game.i18n?.localize("INSPECTRES.BankRoll") ?? "Bank Roll",
     resolutions: summary.resolutions,
@@ -588,7 +590,7 @@ export async function executeStressRoll(
       console.error("[INSPECTRES] Death roll validation failed:", { agentId: agent.id, agentName: agent.name, deathRoll });
       throw new Error(errorMsg);
     }
-    const deathKey = deathRoll as 1 | 2 | 3;
+    const deathKey = deathRoll as D3Result;
     deathOutcome = DEATH_DISMEMBERMENT_CHART[deathKey];
     if (!deathOutcome) {
       const errorMsg = `Death outcome missing for d3 result ${deathKey}. This indicates corrupted DEATH_DISMEMBERMENT_CHART. Agent: ${agent.name} (${agent.id})`;
@@ -664,7 +666,7 @@ export async function executeStressRoll(
 
   // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: agent as Actor });
-  const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
+  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "stress",
     title: game.i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll",
     result: deathOutcome?.result ?? outcome.result,
@@ -734,7 +736,7 @@ export async function executeClientRoll(franchise: RollActor): Promise<void> {
 
   // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
   const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
-  const content = await renderTemplate("systems/inspectres/templates/roll-card.hbs", {
+  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
     rollType: "client",
     title: game.i18n?.localize("INSPECTRES.ClientRoll") ?? "Client Roll",
     client: generated,

--- a/foundry/src/socket/socket-guards.test.ts
+++ b/foundry/src/socket/socket-guards.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isMissionSocketPayload, type MissionSocketPayload } from "./socket-guards.js";
+import { isMissionSocketPayload, getPayloadType, type MissionSocketPayload } from "./socket-guards.js";
 
 describe("Socket payload validation", () => {
   it("accepts valid MissionSocketPayload", () => {
@@ -84,5 +84,28 @@ describe("Socket payload validation", () => {
         franchiseId: "",
       }),
     ).toBe(false); // empty franchiseId is invalid
+  });
+});
+
+describe("getPayloadType", () => {
+  it("returns type string from valid payload", () => {
+    expect(getPayloadType({ type: "missionPoolUpdated", franchiseId: "123" })).toBe("missionPoolUpdated");
+  });
+
+  it("returns undefined for null", () => {
+    expect(getPayloadType(null)).toBeUndefined();
+  });
+
+  it("returns undefined for non-objects", () => {
+    expect(getPayloadType("string")).toBeUndefined();
+    expect(getPayloadType(42)).toBeUndefined();
+  });
+
+  it("returns undefined when type field is missing", () => {
+    expect(getPayloadType({ franchiseId: "123" })).toBeUndefined();
+  });
+
+  it("returns undefined when type field is not a string", () => {
+    expect(getPayloadType({ type: 42 })).toBeUndefined();
   });
 });

--- a/foundry/src/socket/socket-guards.ts
+++ b/foundry/src/socket/socket-guards.ts
@@ -19,7 +19,7 @@ export function isMissionSocketPayload(payload: unknown): payload is MissionSock
   return (
     typeof p["type"] === "string" &&
     typeof p["franchiseId"] === "string" &&
-    (p["franchiseId"] as string).trim().length > 0 &&
+    p["franchiseId"].trim().length > 0 &&
     p["type"] === "missionPoolUpdated"
   );
 }

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -19,6 +19,7 @@ declare class FormDataExtended extends FormData {
  */
 declare namespace foundry.applications.handlebars {
   function loadTemplates(paths: string[] | Record<string, string>): Promise<HandlebarsTemplateDelegate[]>;
+  function renderTemplate(path: string, data?: Record<string, unknown>): Promise<string>;
 }
 
 declare namespace foundry.applications.api {

--- a/foundry/src/utils/day-display.test.ts
+++ b/foundry/src/utils/day-display.test.ts
@@ -1,5 +1,31 @@
-import { describe, it, expect } from "vitest";
-import { setCurrentDaySetting } from "./settings-utils.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getCurrentDaySetting, setCurrentDaySetting } from "./settings-utils.js";
+
+describe("getCurrentDaySetting", () => {
+  const mockGet = vi.fn();
+
+  beforeEach(() => {
+    const g = globalThis as unknown as Record<string, unknown>;
+    g["game"] = {
+      ...(g["game"] as Record<string, unknown>),
+      settings: { get: mockGet },
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns setting value when available", () => {
+    mockGet.mockReturnValue(5);
+    expect(getCurrentDaySetting()).toBe(5);
+  });
+
+  it("returns 1 as fallback when setting is undefined", () => {
+    mockGet.mockReturnValue(undefined);
+    expect(getCurrentDaySetting()).toBe(1);
+  });
+});
 
 describe("Day Settings Validation", () => {
   describe("setCurrentDaySetting validation", () => {

--- a/foundry/src/utils/dev-logger.ts
+++ b/foundry/src/utils/dev-logger.ts
@@ -13,7 +13,7 @@ interface LogEntry {
 
 class DevLogger {
   private logs: LogEntry[] = [];
-  private maxLogs = 500;
+  private readonly maxLogs = 500;
 
   log(
     level: "info" | "warn" | "error",
@@ -75,8 +75,6 @@ class DevLogger {
 let loggerInstance: DevLogger | null = null;
 
 export function getDevLogger(): DevLogger {
-  if (!loggerInstance) {
-    loggerInstance = new DevLogger();
-  }
+  loggerInstance ??= new DevLogger();
   return loggerInstance;
 }

--- a/foundry/src/utils/distribution-dialog.ts
+++ b/foundry/src/utils/distribution-dialog.ts
@@ -74,8 +74,8 @@ export async function buildDistributionConfig(opts: DistributionDialogOptions): 
 
             const num = Number(rawValue);
             // Reject unparsable or negative values with clear context
-            if (isNaN(num) || num < 0) {
-              throw new Error(`Invalid dice count for ${player.name}: "${rawValue}". Please enter a whole number ≥ 0.`);
+            if (Number.isNaN(num) || num < 0) {
+              throw new Error(`Invalid dice count for ${player.name}: "${String(rawValue)}". Please enter a whole number ≥ 0.`);
             }
 
             distribution[player.id] = num;

--- a/foundry/src/utils/handlebars-helpers.ts
+++ b/foundry/src/utils/handlebars-helpers.ts
@@ -17,8 +17,8 @@ export function registerHandlebarsHelpers(): void {
 
   // String helpers
   Handlebars.registerHelper("inspectres-capitalize", (str: string) => {
-    if (typeof str !== "string") return str;
-    return str.charAt(0).toUpperCase() + str.slice(1);
+    if (typeof str === "string") return str.charAt(0).toUpperCase() + str.slice(1);
+    return str;
   });
 
   // Array helpers

--- a/foundry/src/utils/player-filter.ts
+++ b/foundry/src/utils/player-filter.ts
@@ -26,7 +26,7 @@ export function getPlayersInvolved(_actors: RollActor[]): string[] {
 
   // Always include the current GM
   if (game.user?.isGM) {
-    players.add(game.user!.id);
+    players.add(game.user.id);
   }
 
   // In multi-player campaigns, add owners of involved actors

--- a/foundry/src/utils/sheet-tabs.test.ts
+++ b/foundry/src/utils/sheet-tabs.test.ts
@@ -103,4 +103,18 @@ describe("activateTabs", () => {
     expect(notesTab.classList.contains("active")).toBe(true);
     expect(statsTab.classList.contains("active")).toBe(false);
   });
+
+  it("navigates to first tab with Home key", () => {
+    const { element, statsTab, notesBtn } = makeTabFixture("notes");
+    activateTabs(element, "notes");
+    notesBtn.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    expect(statsTab.classList.contains("active")).toBe(true);
+  });
+
+  it("navigates to last tab with End key", () => {
+    const { element, notesTab, statsBtn } = makeTabFixture();
+    activateTabs(element, "stats");
+    statsBtn.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    expect(notesTab.classList.contains("active")).toBe(true);
+  });
 });

--- a/foundry/src/utils/system-cast.integration.test.ts
+++ b/foundry/src/utils/system-cast.integration.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
-import { spawnSync } from "child_process";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../");
+const foundryRoot = resolve(repoRoot, "foundry");
 
 describe("system-cast consolidation (#363)", () => {
   it("should not have manual actor.system casts after #363 consolidation", () => {
@@ -17,7 +22,7 @@ describe("system-cast consolidation (#363)", () => {
       ],
       {
         encoding: "utf-8",
-        cwd: "/Users/ranger/git/inspectres",
+        cwd: repoRoot,
       },
     );
 
@@ -42,7 +47,7 @@ describe("system-cast consolidation (#363)", () => {
 
   it("getActorSystem should be imported and used in agent/franchise files", () => {
     const agentSystemContent = readFileSync(
-      "/Users/ranger/git/inspectres/foundry/src/agent/agent-system-data.ts",
+      resolve(foundryRoot, "src/agent/agent-system-data.ts"),
       "utf-8",
     );
 
@@ -51,7 +56,7 @@ describe("system-cast consolidation (#363)", () => {
 
   it("getActorSystem should be imported and used in franchise utils", () => {
     const franchiseUtilsContent = readFileSync(
-      "/Users/ranger/git/inspectres/foundry/src/franchise/franchise-utils.ts",
+      resolve(foundryRoot, "src/franchise/franchise-utils.ts"),
       "utf-8",
     );
 

--- a/foundry/vite.config.ts
+++ b/foundry/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 const isProduction = process.env.NODE_ENV === "production";
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey=inspectres-vtt
-sonar.exclusions=reference/**,foundry/node_modules/**,docs/node_modules/**,.tmp/,foundry/playwright-report/**,foundry/test-results/**,.semgrep-results/**
+sonar.exclusions=reference/**,foundry/node_modules/**,docs/node_modules/**,.tmp/,foundry/playwright-report/**,.semgrep-results/**
 sonar.test.inclusions=**/*.test.ts
 sonar.python.version=3.12
+sonar.javascript.lcov.reportPaths=foundry/coverage/lcov.info


### PR DESCRIPTION
## Summary

- Applies ~60 mechanical SonarQube fixes across 20+ source files
- Wires vitest lcov coverage output to SonarQube for local scans
- Adds `unit-test` CI job that produces `coverage/lcov.info` artifact
- Updates `.claude/rules/` with patterns discovered during remediation

## Changes

**SonarQube rule fixes:**
- `isNaN` → `Number.isNaN` (S7773)
- `getAttribute("data-*")` → `.dataset["*"]` (S7761) — 6 sites in AgentSheet
- `static override readonly` on `DEFAULT_OPTIONS` / `PARTS` (S1444)
- `if (!x) x = y` → `x ??= y` (S6606)
- `throw new TypeError` for type/value validation failures (S7786) — includes fixing partial conversions found during review
- Removed unnecessary type assertions and non-null assertions (S4325)
- Optional chaining simplification (S6582)
- Extracted variables to avoid nested template literals (S4624)
- Inverted negated conditions (S7735)
- Removed unused imports (S1128)
- `renderTemplate` / `loadTemplates` → `foundry.applications.handlebars.*` (S1874)
- `String(x)` in template literals where type is `unknown` / object (S6551)
- `export { x } from "..."` re-export form (S7763)
- `node:` prefix on built-in imports (S7772)
- Removed empty constructors (S6647/S2094)
- Merged duplicate `:root` blocks in docs CSS

**Coverage → SonarQube:**
- `sonar-project.properties`: `sonar.javascript.lcov.reportPaths=foundry/coverage/lcov.info`
- New `unit-test` CI job runs `npm run test -- --coverage` and uploads `coverage/lcov.info` artifact
- SonarQube runs locally (not from CI) — local workflow: `cd foundry && npm run test -- --coverage && cd .. && sonar-scanner`

**Rules updated:**
- `typescript.md`: `Number.isNaN`, `??=`, `.dataset`, `TypeError`, `node:` imports, re-exports
- `foundry-vite.md`: deprecated V13 globals migration table

## Deferred

Large complexity refactors (S3776 — `roll-executor.ts`, `InSpectresAgent.ts`, `recovery-utils.ts`) were out of scope for mechanical fixes. CSS contrast issues in `inspectres.css` also deferred.