### PR TITLE
chore: Pin Docker image SHAs and add E2E matrix testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,15 +170,24 @@ jobs:
         run: npm run build
 
   e2e:
-    name: E2E tests
+    name: E2E tests (Foundry ${{ matrix.foundry-version }})
     runs-on: ubuntu-latest
     needs: [build, unit-test, typecheck]
     permissions:
       contents: read
+    strategy:
+      matrix:
+        include:
+          - foundry-version: v13
+            image-sha: sha256:41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b
+          - foundry-version: v14
+            image-sha: sha256:383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245
+      fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}
       FOUNDRY_PASSWORD: ${{ secrets.FOUNDRY_PASSWORD }}
       FOUNDRY_LICENSE_KEY: ${{ secrets.FOUNDRY_LICENSE_KEY }}
+      FOUNDRY_IMAGE_SHA: ${{ matrix.image-sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -240,7 +249,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: /tmp/foundry-image.tar
-          key: docker-foundry-v13-${{ runner.os }}-v1
+          key: docker-foundry-${{ matrix.foundry-version }}-${{ runner.os }}-v1
 
       - name: Load Foundry image from cache
         if: steps.foundry-image-cache.outputs.cache-hit == 'true'
@@ -249,8 +258,8 @@ jobs:
       - name: Pull Foundry image and save to cache
         if: steps.foundry-image-cache.outputs.cache-hit != 'true'
         run: |
-          docker pull ghcr.io/felddy/foundryvtt:13
-          docker save ghcr.io/felddy/foundryvtt:13 -o /tmp/foundry-image.tar
+          docker pull ghcr.io/felddy/foundryvtt@${{ matrix.image-sha }}
+          docker save ghcr.io/felddy/foundryvtt@${{ matrix.image-sha }} -o /tmp/foundry-image.tar
 
       - name: Start Foundry container
         working-directory: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,24 +170,16 @@ jobs:
         run: npm run build
 
   e2e:
-    name: E2E tests (Foundry ${{ matrix.foundry-version }})
+    name: E2E tests (Foundry v13)
     runs-on: ubuntu-latest
     needs: [build, unit-test, typecheck]
     permissions:
       contents: read
-    strategy:
-      matrix:
-        include:
-          - foundry-version: "13"
-            image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt:13.351.0
-          - foundry-version: "14"
-            image-sha: 383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt:14.360.0
-      fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}
       FOUNDRY_PASSWORD: ${{ secrets.FOUNDRY_PASSWORD }}
       FOUNDRY_LICENSE_KEY: ${{ secrets.FOUNDRY_LICENSE_KEY }}
-      FOUNDRY_IMAGE_SHA: ${{ matrix.image-sha }}
+      FOUNDRY_IMAGE_SHA: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt:13.351.0
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,8 @@ jobs:
         include:
           - foundry-version: v13
             image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt:13.351.0
+          - foundry-version: v14
+            image-sha: 383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt:14.360.0
       fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}
@@ -256,8 +258,8 @@ jobs:
       - name: Pull Foundry image and save to cache
         if: steps.foundry-image-cache.outputs.cache-hit != 'true'
         run: |
-          docker pull ghcr.io/felddy/foundryvtt@${{ matrix.image-sha }}
-          docker save ghcr.io/felddy/foundryvtt@${{ matrix.image-sha }} -o /tmp/foundry-image.tar
+          docker pull ghcr.io/felddy/foundryvtt@sha256:${{ matrix.image-sha }}
+          docker save ghcr.io/felddy/foundryvtt@sha256:${{ matrix.image-sha }} -o /tmp/foundry-image.tar
 
       - name: Start Foundry container
         working-directory: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - foundry-version: v13
+          - foundry-version: "13"
             image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt:13.351.0
-          - foundry-version: v14
+          - foundry-version: "14"
             image-sha: 383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt:14.360.0
       fail-fast: false
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,16 +170,27 @@ jobs:
         run: npm run build
 
   e2e:
-    name: E2E tests (Foundry v13)
+    name: E2E tests (Foundry ${{ matrix.foundry-version }})
     runs-on: ubuntu-latest
     needs: [build, unit-test, typecheck]
     permissions:
       contents: read
+    strategy:
+      matrix:
+        include:
+          - foundry-version: "13"
+            foundry-version-long: "13.351"
+            image-sha: sha256:41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b
+          - foundry-version: "14"
+            foundry-version-long: "14.351"
+            image-tag: "14"
+      fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}
       FOUNDRY_PASSWORD: ${{ secrets.FOUNDRY_PASSWORD }}
       FOUNDRY_LICENSE_KEY: ${{ secrets.FOUNDRY_LICENSE_KEY }}
-      FOUNDRY_IMAGE_SHA: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt:13.351.0
+      FOUNDRY_IMAGE_SHA: ${{ matrix.image-sha || '' }}
+      FOUNDRY_VERSION: ${{ matrix.foundry-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -236,6 +247,15 @@ jobs:
         working-directory: foundry
         run: npx playwright install chromium
 
+      - name: Set Foundry image reference
+        id: image
+        run: |
+          if [ -n "${{ matrix.image-sha }}" ]; then
+            echo "image_name=ghcr.io/felddy/foundryvtt@${{ matrix.image-sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "image_name=ghcr.io/felddy/foundryvtt:${{ matrix.image-tag }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Cache Foundry Docker image
         id: foundry-image-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
@@ -250,11 +270,13 @@ jobs:
       - name: Pull Foundry image and save to cache
         if: steps.foundry-image-cache.outputs.cache-hit != 'true'
         run: |
-          docker pull ghcr.io/felddy/foundryvtt@sha256:${{ matrix.image-sha }}
-          docker save ghcr.io/felddy/foundryvtt@sha256:${{ matrix.image-sha }} -o /tmp/foundry-image.tar
+          docker pull "${{ steps.image.outputs.image_name }}"
+          docker save "${{ steps.image.outputs.image_name }}" -o /tmp/foundry-image.tar
 
       - name: Start Foundry container
         working-directory: docker
+        env:
+          FOUNDRY_IMAGE_NAME: ${{ steps.image.outputs.image_name }}
         run: docker compose -f docker-compose.ci.yml up -d
 
       - name: Wait for Foundry to be ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,9 @@ jobs:
       matrix:
         include:
           - foundry-version: v13
-            image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt v13
+            image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt:13.351.0
+          - foundry-version: v14
+            image-sha: 383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt:14.360.0
       fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,8 @@ jobs:
       - name: Stop Foundry container
         if: always()
         working-directory: docker
+        env:
+          FOUNDRY_IMAGE_NAME: ${{ steps.image.outputs.image_name }}
         run: docker compose -f docker-compose.ci.yml down
 
       - name: Upload test artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,9 @@ jobs:
       matrix:
         include:
           - foundry-version: v13
-            image-sha: sha256:41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt v13
+            image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt v13
           - foundry-version: v14
-            image-sha: sha256:383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt v14
+            image-sha: 383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt v14
       fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -43,7 +43,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -120,7 +120,7 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -150,7 +150,7 @@ jobs:
     if: needs.check-docs.outputs.changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -190,7 +190,7 @@ jobs:
       FOUNDRY_IMAGE_SHA: ${{ matrix.image-sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -304,7 +304,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
 
@@ -43,7 +43,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
 
@@ -120,7 +120,7 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -150,7 +150,7 @@ jobs:
     if: needs.check-docs.outputs.changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
 
@@ -179,9 +179,9 @@ jobs:
       matrix:
         include:
           - foundry-version: v13
-            image-sha: sha256:41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b
+            image-sha: sha256:41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt v13
           - foundry-version: v14
-            image-sha: sha256:383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245
+            image-sha: sha256:383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt v14
       fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}
@@ -190,7 +190,7 @@ jobs:
       FOUNDRY_IMAGE_SHA: ${{ matrix.image-sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
 
@@ -304,7 +304,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53b118029f4f16f1e2a6  # v6.2.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,6 @@ jobs:
         include:
           - foundry-version: v13
             image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt v13
-          - foundry-version: v14
-            image-sha: 383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt v14
       fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,6 @@ jobs:
         include:
           - foundry-version: v13
             image-sha: 41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b  # felddy/foundryvtt:13.351.0
-          - foundry-version: v14
-            image-sha: 383417dbf3c442a03dcca9a4813b47c7408addaf6d582b7d3b1ee4b65c24a245  # felddy/foundryvtt:14.360.0
       fail-fast: false
     env:
       FOUNDRY_USERNAME: ${{ secrets.FOUNDRY_USERNAME }}

--- a/docker/data-v14/.gitignore
+++ b/docker/data-v14/.gitignore
@@ -1,0 +1,5 @@
+/Backups
+/Config
+/Data
+/Logs
+/container_cache

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -2,10 +2,13 @@
 # felddy/foundryvtt reads FOUNDRY_USERNAME, FOUNDRY_PASSWORD, and
 # FOUNDRY_LICENSE_KEY directly from the environment; no config.json needed.
 # Run as root (0:0) so the container can write to the GHA-checked-out dist/.
+#
+# Image pinned to SHA digest for reproducibility.
+# FOUNDRY_VERSION controls which image is used (default: v13).
 
 services:
   foundry:
-    image: ghcr.io/felddy/foundryvtt:13
+    image: ghcr.io/felddy/foundryvtt@sha256:${FOUNDRY_IMAGE_SHA:-41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b}
     hostname: foundry
     ports:
       - "30000:30000"

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -8,7 +8,7 @@
 
 services:
   foundry:
-    image: ghcr.io/felddy/foundryvtt@sha256:${FOUNDRY_IMAGE_SHA:-41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b}
+    image: ghcr.io/felddy/foundryvtt@sha256:${FOUNDRY_IMAGE_SHA}
     hostname: foundry
     ports:
       - "30000:30000"

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -3,12 +3,12 @@
 # FOUNDRY_LICENSE_KEY directly from the environment; no config.json needed.
 # Run as root (0:0) so the container can write to the GHA-checked-out dist/.
 #
-# Image pinned to SHA digest for reproducibility.
-# FOUNDRY_VERSION controls which image is used (default: v13).
+# Image pinned to SHA digest for reproducibility (v13) or tag (v14).
+# FOUNDRY_IMAGE_NAME set by CI workflow (with SHA or tag already included).
 
 services:
   foundry:
-    image: ghcr.io/felddy/foundryvtt@sha256:${FOUNDRY_IMAGE_SHA}
+    image: ${FOUNDRY_IMAGE_NAME}
     hostname: foundry
     ports:
       - "30000:30000"

--- a/docker/docker-compose.v14-test.yml
+++ b/docker/docker-compose.v14-test.yml
@@ -1,0 +1,18 @@
+# Local v14 testing only — NOT committed for CI use.
+# Uses ./data-v14 for fresh state separate from v13's ./data.
+services:
+  foundry:
+    image: ghcr.io/felddy/foundryvtt:14
+    hostname: foundry
+    ports:
+      - "30000:30000"
+    user: "0:0"
+    environment:
+      FOUNDRY_USERNAME: "${FOUNDRY_USERNAME}"
+      FOUNDRY_PASSWORD: "${FOUNDRY_PASSWORD}"
+      FOUNDRY_LICENSE_KEY: "${FOUNDRY_LICENSE_KEY}"
+      FOUNDRY_HOSTNAME: foundry
+      CONTAINER_PRESERVE_CONFIG: "true"
+    volumes:
+      - ./data-v14:/data
+      - ../foundry/dist:/data/Data/systems/inspectres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,9 +4,9 @@ secrets:
 
 services:
   foundry:
-    # Pinned to V13 — system.json minimum is 13, so we develop and verify against it.
+    # Pinned to V13 — stable, tested configuration.
     # Image pinned to SHA digest for reproducibility.
-    # To upgrade to V14+: update image digest and rebuild.
+    # Ref: ghcr.io/felddy/foundryvtt:13
     image: ghcr.io/felddy/foundryvtt@sha256:41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b
     hostname: foundry
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,8 +5,9 @@ secrets:
 services:
   foundry:
     # Pinned to V13 — system.json minimum is 13, so we develop and verify against it.
-    # To upgrade to V14+: change to ghcr.io/felddy/foundryvtt:release
-    image: ghcr.io/felddy/foundryvtt:13
+    # Image pinned to SHA digest for reproducibility.
+    # To upgrade to V14+: update image digest and rebuild.
+    image: ghcr.io/felddy/foundryvtt@sha256:41d518782f2fabbec887413c56da8ef8175c22fb5a75fde45382661443a8ae6b
     hostname: foundry
     ports:
       - "30000:30000"

--- a/foundry/src/__tests__/e2e/buttons.test.ts
+++ b/foundry/src/__tests__/e2e/buttons.test.ts
@@ -14,7 +14,7 @@
  * - npm run dev watching for changes in another terminal
  */
 
-import { test, expect } from "./fixtures";
+import { test, expect, ELEMENT_WAIT_TIMEOUT } from "./fixtures";
 
 // TODO Phase 2: Add contrast ratio helpers for WCAG AA verification (4.5:1 for normal text)
 // function parseColor(rgb: string): { r: number; g: number; b: number } {
@@ -92,7 +92,7 @@ const button = page.locator("button").first();
     await page.waitForFunction(
       () => document.querySelector("button[disabled]") !== null,
       undefined,
-      { timeout: 5000 },
+      { timeout: ELEMENT_WAIT_TIMEOUT },
     );
     const buttons = page.locator("button[disabled]");
 

--- a/foundry/src/__tests__/e2e/fixtures.ts
+++ b/foundry/src/__tests__/e2e/fixtures.ts
@@ -11,6 +11,12 @@ const READY_TIMEOUT = 60_000;
 // re-render cycle. 30s gives enough headroom for the sheet to stabilize in CI.
 const SHEET_RENDER_TIMEOUT = 30_000;
 
+// Shared timeout for in-test element waits (selectors, locator counts, etc.).
+// 5s is too tight under CI load (especially v14 which has slower init) and
+// causes spurious retries. 15s tolerates CI variance without slowing the
+// suite meaningfully when elements are present.
+export const ELEMENT_WAIT_TIMEOUT = 15_000;
+
 async function dismissStartupNotifications(page: Page): Promise<void> {
   // Foundry V13 startup warnings (hardware acceleration, screen size) are
   // permanent <li class="notification"> elements with no close button — they

--- a/foundry/src/__tests__/e2e/form-fields.test.ts
+++ b/foundry/src/__tests__/e2e/form-fields.test.ts
@@ -8,7 +8,7 @@
  * Run with: npm run test:e2e (with Docker setup)
  */
 
-import { test, expect } from "./fixtures";
+import { test, expect, ELEMENT_WAIT_TIMEOUT } from "./fixtures";
 
 // ApplicationV2 re-renders briefly detach elements. waitForSelector on ".inspectres" can
 // time out even when the sheet is logically visible. Use waitForFunction + getBoundingClientRect
@@ -118,7 +118,7 @@ test.describe("Form field rendering and input validation (E2E - Playwright)", ()
     await waitForSheet(page);
     // The textarea lives in the Notes tab — navigate there like a real user would
     await page.click(".inspectres [role='tab'][aria-controls='tab-notes']");
-    await page.waitForSelector(".inspectres textarea", { timeout: 5000 });
+    await page.waitForSelector(".inspectres textarea", { timeout: ELEMENT_WAIT_TIMEOUT });
 
     const textarea = page.locator(".inspectres textarea").first();
     await expect(textarea).toBeVisible();

--- a/foundry/src/__tests__/e2e/global-setup.ts
+++ b/foundry/src/__tests__/e2e/global-setup.ts
@@ -5,14 +5,15 @@
  *   1. Decline usage data sharing dialog (if present)
  *   2. Dismiss tour overlay (ESC)
  *   3. Create test world (system: inspectres) — only if none exists
- *   4. Launch world
+ *   4. Launch world (v13) or auto-launches on submit (v14)
  *   5. Join as Gamemaster (no password — fresh world)
  *   6. Wait until `game.ready === true`
  *   7. Provision N test worker users (test-worker-0 … test-worker-N) via Foundry User API
  *   8. Save a separate storage-state file for each worker
  *
  * Idempotent: if a world already exists and game is reachable, just verifies it.
- * Selectors verified against Foundry V13 (felddy/foundryvtt:13).
+ * Supports Foundry v13 (form-based dialog, hidden launch link) and v14
+ * (standalone /create page, package gallery system selector, auto-launch on submit).
  */
 
 import path from "node:path";
@@ -103,16 +104,42 @@ async function dismissTourOverlay(page: Page): Promise<void> {
   await page.waitForTimeout(300);
 }
 
+/**
+ * Detects whether the current page is Foundry v14's setup UI.
+ *
+ * v14 vs v13 distinguishing markers:
+ * - v14: Create World button leads to a standalone `/create` page
+ * - v14: System selection via package gallery (`li.package.system`)
+ * - v14: Form field renamed `name="world-id"` (was `name="id"` in v13)
+ * - v14: Auto-launches world on submit (no separate launch button click)
+ */
+async function detectIsV14Setup(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const hasGallery = !!document.querySelector("li.package.system, li.package.module");
+    const hasV1Window = !!document.querySelector(".window-app form.application");
+    return hasGallery && !hasV1Window;
+  });
+}
+
 async function createWorldIfNeeded(page: Page): Promise<void> {
   const exists = await page.evaluate(
-    (id) => !!document.querySelector(`#worlds-list [data-package-id="${id}"]`),
+    (id) => !!document.querySelector(`[data-package-id="${id}"]`),
     WORLD_ID,
   );
   if (exists) return;
 
   await page.click('button[data-action="worldCreate"]');
-  await page.waitForTimeout(1500);
+  await page.waitForTimeout(2000);
 
+  const isV14 = await detectIsV14Setup(page);
+  if (isV14) {
+    await createWorldV14(page);
+  } else {
+    await createWorldV13(page);
+  }
+}
+
+async function createWorldV13(page: Page): Promise<void> {
   await page.fill('input[name="title"]', WORLD_TITLE);
   await page.waitForTimeout(200);
   await page.fill('input[name="id"]', WORLD_ID);
@@ -129,15 +156,39 @@ async function createWorldIfNeeded(page: Page): Promise<void> {
     (form as HTMLFormElement).requestSubmit(submitBtn as HTMLButtonElement);
     return true;
   });
-  if (!submitted) throw new Error("Could not submit Create World form");
+  if (!submitted) throw new Error("Could not submit Create World form (v13)");
   await page.waitForTimeout(3000);
 
-  // Verify the world appeared
   const created = await page.evaluate(
     (id) => !!document.querySelector(`#worlds-list [data-package-id="${id}"]`),
     WORLD_ID,
   );
-  if (!created) throw new Error(`World ${WORLD_ID} did not appear after creation`);
+  if (!created) throw new Error(`World ${WORLD_ID} did not appear after creation (v13)`);
+}
+
+async function createWorldV14(page: Page): Promise<void> {
+  await page.fill('input[name="title"]', WORLD_TITLE);
+  await page.waitForTimeout(200);
+  await page.fill('input[name="world-id"]', WORLD_ID);
+  await page.waitForTimeout(200);
+
+  // V14 hides the native <select name="system"> behind a clickable package gallery.
+  // Clicking the system <li> sets the select value via Foundry's framework.
+  const systemPackage = await page.$(`li.package.system[data-package-id="${SYSTEM_ID}"]`);
+  if (!systemPackage) {
+    throw new Error(`V14 system package li not found for ${SYSTEM_ID}`);
+  }
+  await systemPackage.click();
+  await page.waitForTimeout(300);
+
+  // Submit the form. V14's submit button is a plain <button type="submit">Continue</button>.
+  await page.click('button[type="submit"]:not([data-action="cancel"])');
+
+  // V14 auto-launches the world on submit and redirects to /join (the players page).
+  await page.waitForURL((u) => u.pathname.includes("/join") || u.pathname.includes("/players"), {
+    timeout: 30_000,
+  });
+  await page.waitForTimeout(1500);
 }
 
 const DEFAULT_JOIN_TIMEOUTS = { url: 30_000, ready: 60_000 };
@@ -171,24 +222,25 @@ async function joinAsUser(page: Page, username: string, timeouts = DEFAULT_JOIN_
 }
 
 async function launchAndJoin(page: Page): Promise<void> {
-  console.log('[launchAndJoin] Current URL before launch:', page.url());
+  console.log("[launchAndJoin] Current URL before launch:", page.url());
 
-  // Detect Foundry version by checking for V2 elements (v14 uses <dialog>, v13 uses <form>)
-  const isV2 = await page.evaluate(() => {
-    const appWindow = document.querySelector('dialog.app') || document.querySelector('form.window');
-    return !!(appWindow instanceof HTMLDialogElement);
-  });
-  console.log('[launchAndJoin] Detected V' + (isV2 ? '14 (V2)' : '13 (V1)'));
-
-  if (isV2) {
-    // V14: Try direct API if available, fall back to click
-    console.log('[launchAndJoin] Using V14 workflow...');
-    await launchAndJoinV14(page);
-  } else {
-    // V13: CSS override method (proven to work)
-    console.log('[launchAndJoin] Using V13 workflow...');
-    await launchAndJoinV13(page);
+  // V14 auto-launches the world on createWorld submit, so we may already be on /join.
+  // V13 leaves us on /setup with a separate launch button to click.
+  const url = page.url();
+  if (url.includes("/join") || url.includes("/players")) {
+    // V14 auto-launches on world creation and lands on /players (User
+    // Management page). /join is the actual login form and is reachable by
+    // server redirect when navigating fresh. Explicitly navigate to /join.
+    console.log("[launchAndJoin] V14 auto-launch landed on", url, "→ navigating to /join");
+    await page.goto(`${FOUNDRY_URL}/join`, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector('select[name="userid"]', { timeout: 30_000 });
+    await joinAsUser(page, "Gamemaster");
+    return;
   }
+
+  // Still on /setup: must click the launch button (v13 path).
+  console.log("[launchAndJoin] Still on /setup; using v13 launch flow");
+  await launchAndJoinV13(page);
 }
 
 async function launchAndJoinV13(page: Page): Promise<void> {
@@ -219,51 +271,6 @@ async function launchAndJoinV13(page: Page): Promise<void> {
   console.log('[launchAndJoin] V13: Waiting for /join redirect...');
   await page.waitForURL(/\/join/, { timeout: 30_000 });
   console.log('[launchAndJoin] V13: ✓ Navigated to /join');
-  await page.waitForTimeout(1500);
-  await joinAsUser(page, "Gamemaster");
-}
-
-async function launchAndJoinV14(page: Page): Promise<void> {
-  // V14: May have different button structure or require different interaction pattern.
-  // Start with same CSS approach as V13, but log any differences.
-  const hasLaunchButton = await page.evaluate(
-    () => !!document.querySelector('[data-package-id="test-world"] a[data-action="worldLaunch"]'),
-  );
-
-  if (hasLaunchButton) {
-    // V14 has the same button structure as V13; try same approach
-    await page.evaluate(() => {
-      const container = document.querySelector('[data-package-id="test-world"]') as HTMLElement | null;
-      if (container) {
-        container.style.setProperty('display', 'block', 'important');
-        container.style.setProperty('visibility', 'visible', 'important');
-      }
-      const launchBtn = document.querySelector('[data-package-id="test-world"] a[data-action="worldLaunch"]') as HTMLElement | null;
-      if (launchBtn) {
-        launchBtn.style.setProperty('display', 'block', 'important');
-        launchBtn.style.setProperty('visibility', 'visible', 'important');
-        launchBtn.style.setProperty('opacity', '1', 'important');
-      }
-    });
-
-    console.log('[launchAndJoin] V14: Clicking world launch button...');
-    await page.click('[data-package-id="test-world"] a[data-action="worldLaunch"]', {
-      timeout: 5000,
-    });
-  } else {
-    // V14 may have a different UI; try alternate selectors
-    console.log('[launchAndJoin] V14: Launch button not found at expected selector, trying alternate...');
-    const altButton = await page.$('[role="button"][data-action="worldLaunch"], button[data-action="worldLaunch"]');
-    if (altButton) {
-      await altButton.click();
-    } else {
-      throw new Error('V14 launch button not found at any known selector');
-    }
-  }
-
-  console.log('[launchAndJoin] V14: Waiting for /join redirect...');
-  await page.waitForURL(/\/join/, { timeout: 30_000 });
-  console.log('[launchAndJoin] V14: ✓ Navigated to /join');
   await page.waitForTimeout(1500);
   await joinAsUser(page, "Gamemaster");
 }

--- a/foundry/src/__tests__/e2e/global-setup.ts
+++ b/foundry/src/__tests__/e2e/global-setup.ts
@@ -107,18 +107,12 @@ async function dismissTourOverlay(page: Page): Promise<void> {
 /**
  * Detects whether the current page is Foundry v14's setup UI.
  *
- * v14 vs v13 distinguishing markers:
- * - v14: Create World button leads to a standalone `/create` page
- * - v14: System selection via package gallery (`li.package.system`)
- * - v14: Form field renamed `name="world-id"` (was `name="id"` in v13)
- * - v14: Auto-launches world on submit (no separate launch button click)
+ * v14 renamed the world id field from `name="id"` (v13) to `name="world-id"`.
+ * This field name is the most reliable distinguisher since both versions show
+ * a system package list elsewhere on the setup screen.
  */
 async function detectIsV14Setup(page: Page): Promise<boolean> {
-  return page.evaluate(() => {
-    const hasGallery = !!document.querySelector("li.package.system, li.package.module");
-    const hasV1Window = !!document.querySelector(".window-app form.application");
-    return hasGallery && !hasV1Window;
-  });
+  return page.evaluate(() => !!document.querySelector('input[name="world-id"]'));
 }
 
 async function createWorldIfNeeded(page: Page): Promise<void> {

--- a/foundry/src/__tests__/e2e/global-setup.ts
+++ b/foundry/src/__tests__/e2e/global-setup.ts
@@ -143,6 +143,21 @@ async function createWorldIfNeeded(page: Page): Promise<void> {
 const DEFAULT_JOIN_TIMEOUTS = { url: 30_000, ready: 60_000 };
 
 async function joinAsUser(page: Page, username: string, timeouts = DEFAULT_JOIN_TIMEOUTS): Promise<void> {
+  // Check for critical failure or error page
+  const criticalFailure = await page.evaluate(() => {
+    const text = document.body.textContent || '';
+    if (text.includes('Critical Failure')) {
+      const errorSection = document.querySelector('section') || document.body;
+      return { isCritical: true, errorText: errorSection.textContent };
+    }
+    return { isCritical: false };
+  });
+
+  if (criticalFailure.isCritical) {
+    const errorMsg = criticalFailure.errorText?.slice(0, 500) || 'Unknown error';
+    throw new Error(`Foundry join failed with critical error: ${errorMsg}`);
+  }
+
   await page.selectOption('select[name="userid"]', { label: username });
   await page.click('button[type="submit"]:has-text("Join Game Session")');
   await page.waitForURL(/\/game/, { timeout: timeouts.url });
@@ -156,12 +171,40 @@ async function joinAsUser(page: Page, username: string, timeouts = DEFAULT_JOIN_
 }
 
 async function launchAndJoin(page: Page): Promise<void> {
-  // The launch link is hover-only (CSS `:hover` reveals it), so click via DOM.
+  // The launch link is hidden by default (CSS `:hover` reveals it).
+  // We need to make it visible and clickable before Playwright can click it.
+  console.log('[launchAndJoin] Current URL before launch:', page.url());
+
+  // Make the world package container visible and reveal the launch button
   await page.evaluate(() => {
-    const link = document.querySelector('a[data-action="worldLaunch"]') as HTMLElement | null;
-    link?.click();
+    const container = document.querySelector('[data-package-id="test-world"]') as HTMLElement | null;
+    if (!container) {
+      throw new Error('World package container not found');
+    }
+    // Force container visibility
+    container.style.setProperty('display', 'block', 'important');
+    container.style.setProperty('visibility', 'visible', 'important');
+
+    // Find launch button and make it visible (it's normally hidden by :hover CSS)
+    const launchBtn = container.querySelector('a[data-action="worldLaunch"]') as HTMLElement | null;
+    if (!launchBtn) {
+      throw new Error('World launch button not found');
+    }
+    // Override CSS hover state to always show the button
+    launchBtn.style.setProperty('display', 'block', 'important');
+    launchBtn.style.setProperty('visibility', 'visible', 'important');
+    launchBtn.style.setProperty('opacity', '1', 'important');
   });
+
+  // Now click the visible button
+  console.log('[launchAndJoin] Clicking world launch button...');
+  await page.click('[data-package-id="test-world"] a[data-action="worldLaunch"]', {
+    timeout: 5000,
+  });
+
+  console.log('[launchAndJoin] Waiting for /join redirect...');
   await page.waitForURL(/\/join/, { timeout: 30_000 });
+  console.log('[launchAndJoin] ✓ Navigated to /join');
   await page.waitForTimeout(1500);
   await joinAsUser(page, "Gamemaster");
 }

--- a/foundry/src/__tests__/e2e/global-setup.ts
+++ b/foundry/src/__tests__/e2e/global-setup.ts
@@ -171,40 +171,99 @@ async function joinAsUser(page: Page, username: string, timeouts = DEFAULT_JOIN_
 }
 
 async function launchAndJoin(page: Page): Promise<void> {
-  // The launch link is hidden by default (CSS `:hover` reveals it).
-  // We need to make it visible and clickable before Playwright can click it.
   console.log('[launchAndJoin] Current URL before launch:', page.url());
 
-  // Make the world package container visible and reveal the launch button
+  // Detect Foundry version by checking for V2 elements (v14 uses <dialog>, v13 uses <form>)
+  const isV2 = await page.evaluate(() => {
+    const appWindow = document.querySelector('dialog.app') || document.querySelector('form.window');
+    return !!(appWindow instanceof HTMLDialogElement);
+  });
+  console.log('[launchAndJoin] Detected V' + (isV2 ? '14 (V2)' : '13 (V1)'));
+
+  if (isV2) {
+    // V14: Try direct API if available, fall back to click
+    console.log('[launchAndJoin] Using V14 workflow...');
+    await launchAndJoinV14(page);
+  } else {
+    // V13: CSS override method (proven to work)
+    console.log('[launchAndJoin] Using V13 workflow...');
+    await launchAndJoinV13(page);
+  }
+}
+
+async function launchAndJoinV13(page: Page): Promise<void> {
+  // V13: The launch link is hidden by default (CSS `:hover` reveals it).
+  // Force visibility via JavaScript before clicking.
   await page.evaluate(() => {
     const container = document.querySelector('[data-package-id="test-world"]') as HTMLElement | null;
     if (!container) {
       throw new Error('World package container not found');
     }
-    // Force container visibility
     container.style.setProperty('display', 'block', 'important');
     container.style.setProperty('visibility', 'visible', 'important');
 
-    // Find launch button and make it visible (it's normally hidden by :hover CSS)
     const launchBtn = container.querySelector('a[data-action="worldLaunch"]') as HTMLElement | null;
     if (!launchBtn) {
       throw new Error('World launch button not found');
     }
-    // Override CSS hover state to always show the button
     launchBtn.style.setProperty('display', 'block', 'important');
     launchBtn.style.setProperty('visibility', 'visible', 'important');
     launchBtn.style.setProperty('opacity', '1', 'important');
   });
 
-  // Now click the visible button
-  console.log('[launchAndJoin] Clicking world launch button...');
+  console.log('[launchAndJoin] V13: Clicking world launch button...');
   await page.click('[data-package-id="test-world"] a[data-action="worldLaunch"]', {
     timeout: 5000,
   });
 
-  console.log('[launchAndJoin] Waiting for /join redirect...');
+  console.log('[launchAndJoin] V13: Waiting for /join redirect...');
   await page.waitForURL(/\/join/, { timeout: 30_000 });
-  console.log('[launchAndJoin] ✓ Navigated to /join');
+  console.log('[launchAndJoin] V13: ✓ Navigated to /join');
+  await page.waitForTimeout(1500);
+  await joinAsUser(page, "Gamemaster");
+}
+
+async function launchAndJoinV14(page: Page): Promise<void> {
+  // V14: May have different button structure or require different interaction pattern.
+  // Start with same CSS approach as V13, but log any differences.
+  const hasLaunchButton = await page.evaluate(
+    () => !!document.querySelector('[data-package-id="test-world"] a[data-action="worldLaunch"]'),
+  );
+
+  if (hasLaunchButton) {
+    // V14 has the same button structure as V13; try same approach
+    await page.evaluate(() => {
+      const container = document.querySelector('[data-package-id="test-world"]') as HTMLElement | null;
+      if (container) {
+        container.style.setProperty('display', 'block', 'important');
+        container.style.setProperty('visibility', 'visible', 'important');
+      }
+      const launchBtn = document.querySelector('[data-package-id="test-world"] a[data-action="worldLaunch"]') as HTMLElement | null;
+      if (launchBtn) {
+        launchBtn.style.setProperty('display', 'block', 'important');
+        launchBtn.style.setProperty('visibility', 'visible', 'important');
+        launchBtn.style.setProperty('opacity', '1', 'important');
+      }
+    });
+
+    console.log('[launchAndJoin] V14: Clicking world launch button...');
+    await page.click('[data-package-id="test-world"] a[data-action="worldLaunch"]', {
+      timeout: 5000,
+    });
+  } else {
+    // V14 may have a different UI; try alternate selectors
+    console.log('[launchAndJoin] V14: Launch button not found at expected selector, trying alternate...');
+    const altButton = await page.$('[role="button"][data-action="worldLaunch"], button[data-action="worldLaunch"]');
+    if (altButton) {
+      await altButton.click();
+    } else {
+      throw new Error('V14 launch button not found at any known selector');
+    }
+  }
+
+  console.log('[launchAndJoin] V14: Waiting for /join redirect...');
+  await page.waitForURL(/\/join/, { timeout: 30_000 });
+  console.log('[launchAndJoin] V14: ✓ Navigated to /join');
   await page.waitForTimeout(1500);
   await joinAsUser(page, "Gamemaster");
 }

--- a/foundry/src/__tests__/e2e/sheet-navigation.test.ts
+++ b/foundry/src/__tests__/e2e/sheet-navigation.test.ts
@@ -8,7 +8,7 @@
  * Run with: npm run test:e2e (with Docker setup)
  */
 
-import { test, expect } from "./fixtures";
+import { test, expect, ELEMENT_WAIT_TIMEOUT } from "./fixtures";
 
 // ApplicationV2 re-renders briefly detach elements. waitForSelector on ".inspectres" can
 // time out even when the sheet is logically visible. Use waitForFunction + getBoundingClientRect
@@ -59,7 +59,7 @@ test.describe("Sheet navigation and tab switching (E2E - Playwright)", () => {
     await waitForSheet(page);
     const tabs = page.locator(".inspectres [role='tab']");
     // Ensure at least 2 tabs exist to test switching behavior
-    await expect(tabs).toHaveCount(2, { timeout: 5000 });
+    await expect(tabs).toHaveCount(2, { timeout: ELEMENT_WAIT_TIMEOUT });
     const secondTab = tabs.nth(1);
     // Foundry tabs link to panels via aria-controls (referencing the panel's id),
     // not via id+aria-labelledby on the panel. See sheet-tabs HBS for relationship.
@@ -85,14 +85,14 @@ test.describe("Sheet navigation and tab switching (E2E - Playwright)", () => {
     });
     // Wait for the panel to become visible — tab switching toggles the .active class
     // which maps display:none → display:block
-    await expect(page.locator(`.inspectres [role='tabpanel']#${secondTabPanelId}`)).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(`.inspectres [role='tabpanel']#${secondTabPanelId}`)).toBeVisible({ timeout: ELEMENT_WAIT_TIMEOUT });
 
     const selected = await secondTab.getAttribute("aria-selected");
     expect(selected).toBe("true");
 
     // Verify the visible panel is the one controlled by the second tab
     const visiblePanel = page.locator(".inspectres [role='tabpanel']:visible");
-    await expect(visiblePanel).toHaveCount(1, { timeout: 5000 });
+    await expect(visiblePanel).toHaveCount(1, { timeout: ELEMENT_WAIT_TIMEOUT });
     const visiblePanelId = await visiblePanel.first().getAttribute("id");
     expect(visiblePanelId).toBe(secondTabPanelId);
 

--- a/foundry/system.json
+++ b/foundry/system.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "14"
   },
   "authors": [
     {

--- a/foundry/system.json
+++ b/foundry/system.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "13.351"
   },
   "authors": [
     {

--- a/foundry/system.json
+++ b/foundry/system.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "14"
+    "verified": "13"
   },
   "authors": [
     {


### PR DESCRIPTION
## Summary

- Pin Foundry v13 Docker image to SHA256 digest for reproducible pulls
- Establish E2E test matrix running against both Foundry v13 and v14
- Centralize element wait timeout to reduce CI flake on slower v14 init

## What Changed

- `docker/docker-compose.yml`: v13 image pinned to SHA (`sha256:41d51878…`)
- `docker/docker-compose.ci.yml`: image resolved from `FOUNDRY_IMAGE_NAME` env var so the matrix can swap between versions per job
- `.github/workflows/ci.yml`: E2E job runs as a matrix over `{v13, v14}`; v13 pinned by SHA, v14 by `:14` tag (SHA pin pending — see follow-up note)
- `foundry/src/__tests__/e2e/global-setup.ts`: detector for v14's setup screen narrowed to `input[name="world-id"]` (the most reliable v13/v14 distinguisher); v13 launch flow restored
- `foundry/src/__tests__/e2e/fixtures.ts`: new `ELEMENT_WAIT_TIMEOUT = 15_000` constant
- `foundry/src/__tests__/e2e/{buttons,form-fields,sheet-navigation}.test.ts`: replaced 5s element-wait timeouts with `ELEMENT_WAIT_TIMEOUT` to tolerate CI variance
- `foundry/system.json`: `compatibility.verified` set to v14 (newest tested)

## CI Results

All 9 jobs green on the matrix run:
- E2E tests (Foundry 13): 19 passed, 1 skipped
- E2E tests (Foundry 14): 19 passed, 1 skipped
- Lint, Type check, Unit tests + coverage, Build, Spell check, Docs build: green

## Notes / Follow-ups

- v14 currently uses the floating `:14` tag rather than a SHA digest. Pinning to a specific v14.x.x SHA can be done in a follow-up once a target release is chosen (user preference: pin to specific releases like v13.6.0, v14.2.1 rather than major tags).
- The compose-down step required mirroring `FOUNDRY_IMAGE_NAME` env from the start step (compose resolves `image:` field at down-time as well).

Closes #488
Closes #448
Closes #460