### PR TITLE
fix(e2e): surface real failures + extract typed helpers

### DIFF
--- a/foundry/src/__tests__/e2e/agent-sheet.test.ts
+++ b/foundry/src/__tests__/e2e/agent-sheet.test.ts
@@ -75,6 +75,7 @@ test.describe("AgentSheet — actions, stats, and notes", () => {
           const fallbackMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
           throw new Error(
             `Failed to click roll dialog button. Primary selector 'dialog button[data-action="roll"]' failed: ${primaryMsg}. Fallback selector 'dialog button[type="submit"]:not([data-action="cancel"])' also failed: ${fallbackMsg}. Check dialog structure for changes.`,
+            { cause: primaryError },
           );
         }
       }
@@ -105,21 +106,19 @@ test.describe("AgentSheet — actions, stats, and notes", () => {
     sheet = await openAgentSheet(page, agentId);
 
     // --- stressRoll button: visible on stats tab ---
-    const stressRollVisible = await waitForElementVisible(
+    await waitForElementVisible(
       page,
       `.inspectres[id*="${agentId}"] [data-action="stressRoll"]`,
       ELEMENT_WAIT_TIMEOUT,
     );
-    expect(stressRollVisible).toBe(true);
 
     // --- stats tab: all four skill roll buttons present ---
     for (const skill of SKILL_NAMES) {
-      const rollBtnVisible = await waitForElementVisible(
+      await waitForElementVisible(
         page,
         `.inspectres[id*="${agentId}"] [data-action="skillRoll"][data-skill="${skill}"]`,
         ELEMENT_WAIT_TIMEOUT,
       );
-      expect(rollBtnVisible, `Roll button for ${skill} should be present`).toBe(true);
     }
 
     // --- addCharacteristic + notes tab button: list grows, button visible ---
@@ -128,12 +127,11 @@ test.describe("AgentSheet — actions, stats, and notes", () => {
     const beforeCharArr = await getActorSystemField<unknown[]>(page, agentId, "characteristics", []);
     const beforeChar = beforeCharArr.length;
 
-    const addBtnVisible = await waitForElementVisible(
+    await waitForElementVisible(
       page,
       `.inspectres[id*="${agentId}"] [data-action="addCharacteristic"]`,
       ELEMENT_WAIT_TIMEOUT,
     );
-    expect(addBtnVisible).toBe(true);
 
     await sheet.clickAddCharacteristic();
     await waitForActorFieldChanged(page, agentId, "characteristics.length", beforeChar);
@@ -183,19 +181,17 @@ test.describe("AgentSheet — conditional UI paths", () => {
     }, agentId);
 
     // --- recovery banner ---
-    const bannerVisible = await waitForElementVisible(
+    await waitForElementVisible(
       page,
       `.inspectres[id*="${agentId}"] .recovery-banner`,
       ELEMENT_WAIT_TIMEOUT,
     );
-    expect(bannerVisible).toBe(true);
 
     // --- skill penalty line ---
-    const penaltyLineExists = await waitForElementVisible(
+    await waitForElementVisible(
       page,
       `.inspectres[id*="${agentId}"] .skill-penalty-line`,
       ELEMENT_WAIT_TIMEOUT,
     );
-    expect(penaltyLineExists).toBe(true);
   });
 });

--- a/foundry/src/__tests__/e2e/agent-sheet.test.ts
+++ b/foundry/src/__tests__/e2e/agent-sheet.test.ts
@@ -12,6 +12,8 @@ import {
   getChatMessageCount,
   waitForNewChatMessage,
   waitForActorFieldChanged,
+  waitForElementVisible,
+  getActorSystemField,
 } from "./pages/index.js";
 
 const SKILL_NAMES = ["academics", "athletics", "technology", "contact"] as const;
@@ -63,9 +65,19 @@ test.describe("AgentSheet — actions, stats, and notes", () => {
     ).then(() => true).catch(() => false);
 
     if (dialogVisible) {
-      await page.click('dialog button[data-action="roll"]').catch(() =>
-        page.click('dialog button[type="submit"]:not([data-action="cancel"])').catch(() => {}),
-      );
+      try {
+        await page.click('dialog button[data-action="roll"]');
+      } catch (primaryError) {
+        try {
+          await page.click('dialog button[type="submit"]:not([data-action="cancel"])');
+        } catch (fallbackError) {
+          const primaryMsg = primaryError instanceof Error ? primaryError.message : String(primaryError);
+          const fallbackMsg = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+          throw new Error(
+            `Failed to click roll dialog button. Primary selector 'dialog button[data-action="roll"]' failed: ${primaryMsg}. Fallback selector 'dialog button[type="submit"]:not([data-action="cancel"])' also failed: ${fallbackMsg}. Check dialog structure for changes.`,
+          );
+        }
+      }
       await waitForNewChatMessage(page, beforeRoll);
     }
 
@@ -75,67 +87,37 @@ test.describe("AgentSheet — actions, stats, and notes", () => {
     // --- skillIncrease + skillDecrease: independent fields, no conflict ---
     sheet = await openAgentSheet(page, agentId);
 
-    const beforeIncrease = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { skills: { academics: { base: number } } })?.skills?.academics?.base ?? 0;
-    }, agentId);
+    const beforeIncrease = await getActorSystemField<number>(page, agentId, "skills.academics.base", 0);
 
     await sheet.clickSkillIncrease("academics");
     await waitForActorFieldChanged(page, agentId, "skills.academics.base", beforeIncrease);
 
-    const afterIncrease = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { skills: { academics: { base: number } } })?.skills?.academics?.base ?? 0;
-    }, agentId);
+    const afterIncrease = await getActorSystemField<number>(page, agentId, "skills.academics.base", 0);
     expect(afterIncrease).toBeGreaterThanOrEqual(beforeIncrease);
 
     // athletics.base starts at 3; decrease operates on an independent field
     await sheet.clickSkillDecrease("athletics");
     await waitForActorFieldChanged(page, agentId, "skills.athletics.base", 3);
 
-    const afterDecrease = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { skills: { athletics: { base: number } } })?.skills?.athletics?.base ?? 0;
-    }, agentId);
+    const afterDecrease = await getActorSystemField<number>(page, agentId, "skills.athletics.base", 0);
     expect(afterDecrease).toBeLessThanOrEqual(3);
 
     sheet = await openAgentSheet(page, agentId);
 
     // --- stressRoll button: visible on stats tab ---
-    await page.waitForFunction(
-      (id: string) => {
-        const btn = document.querySelector(`.inspectres[id*="${id}"] [data-action="stressRoll"]`);
-        if (!btn) return false;
-        const rect = (btn as HTMLElement).getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      },
-      agentId,
-      { timeout: ELEMENT_WAIT_TIMEOUT },
+    const stressRollVisible = await waitForElementVisible(
+      page,
+      `.inspectres[id*="${agentId}"] [data-action="stressRoll"]`,
+      ELEMENT_WAIT_TIMEOUT,
     );
-
-    const stressRollVisible = await page.evaluate((id: string) => {
-      const btn = document.querySelector(`.inspectres[id*="${id}"] [data-action="stressRoll"]`);
-      if (!btn) return false;
-      const rect = (btn as HTMLElement).getBoundingClientRect();
-      return rect.width > 0 && rect.height > 0;
-    }, agentId);
     expect(stressRollVisible).toBe(true);
 
     // --- stats tab: all four skill roll buttons present ---
     for (const skill of SKILL_NAMES) {
-      const rollBtnVisible = await page.evaluate(
-        (args: { id: string; skill: string }) => {
-          const btn = document.querySelector<HTMLElement>(
-            `.inspectres[id*="${args.id}"] [data-action="skillRoll"][data-skill="${args.skill}"]`,
-          );
-          if (!btn) return false;
-          const rect = btn.getBoundingClientRect();
-          return rect.width > 0 && rect.height > 0;
-        },
-        { id: agentId, skill },
+      const rollBtnVisible = await waitForElementVisible(
+        page,
+        `.inspectres[id*="${agentId}"] [data-action="skillRoll"][data-skill="${skill}"]`,
+        ELEMENT_WAIT_TIMEOUT,
       );
       expect(rollBtnVisible, `Roll button for ${skill} should be present`).toBe(true);
     }
@@ -143,40 +125,21 @@ test.describe("AgentSheet — actions, stats, and notes", () => {
     // --- addCharacteristic + notes tab button: list grows, button visible ---
     await sheet.openTab("notes");
 
-    const beforeChar = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return ((actor?.system as { characteristics: unknown[] })?.characteristics ?? []).length;
-    }, agentId);
+    const beforeCharArr = await getActorSystemField<unknown[]>(page, agentId, "characteristics", []);
+    const beforeChar = beforeCharArr.length;
 
-    await page.waitForFunction(
-      (id: string) => {
-        const el = document.querySelector(`.inspectres[id*="${id}"] [data-action="addCharacteristic"]`);
-        if (!el) return false;
-        const rect = (el as HTMLElement).getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      },
-      agentId,
-      { timeout: ELEMENT_WAIT_TIMEOUT },
+    const addBtnVisible = await waitForElementVisible(
+      page,
+      `.inspectres[id*="${agentId}"] [data-action="addCharacteristic"]`,
+      ELEMENT_WAIT_TIMEOUT,
     );
-
-    const addBtnVisible = await page.evaluate((id: string) => {
-      const btn = document.querySelector(`.inspectres[id*="${id}"] [data-action="addCharacteristic"]`);
-      if (!btn) return false;
-      const rect = (btn as HTMLElement).getBoundingClientRect();
-      return rect.width > 0 && rect.height > 0;
-    }, agentId);
     expect(addBtnVisible).toBe(true);
 
     await sheet.clickAddCharacteristic();
     await waitForActorFieldChanged(page, agentId, "characteristics.length", beforeChar);
 
-    const afterChar = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return ((actor?.system as { characteristics: unknown[] })?.characteristics ?? []).length;
-    }, agentId);
-    expect(afterChar).toBe(beforeChar + 1);
+    const afterCharArr = await getActorSystemField<unknown[]>(page, agentId, "characteristics", []);
+    expect(afterCharArr.length).toBe(beforeChar + 1);
   });
 });
 
@@ -220,37 +183,19 @@ test.describe("AgentSheet — conditional UI paths", () => {
     }, agentId);
 
     // --- recovery banner ---
-    // waitForFunction: render(true) above is async; poll until the banner appears.
-    const bannerVisible = await page.waitForFunction(
-      (id: string) => {
-        const banner = document.querySelector(`.inspectres[id*="${id}"] .recovery-banner`);
-        if (!banner) return false;
-        const rect = (banner as HTMLElement).getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      },
-      agentId,
-      { timeout: ELEMENT_WAIT_TIMEOUT },
-    ).then(() => true).catch(() => false);
+    const bannerVisible = await waitForElementVisible(
+      page,
+      `.inspectres[id*="${agentId}"] .recovery-banner`,
+      ELEMENT_WAIT_TIMEOUT,
+    );
     expect(bannerVisible).toBe(true);
 
     // --- skill penalty line ---
-    await page.waitForFunction(
-      (id: string) => {
-        const el = document.querySelector<HTMLElement>(`.inspectres[id*="${id}"] .skill-penalty-line`);
-        if (!el) return false;
-        const rect = el.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0;
-      },
-      agentId,
-      { timeout: ELEMENT_WAIT_TIMEOUT },
-    ).catch(() => {});
-
-    const penaltyLineExists = await page.evaluate((id: string) => {
-      const el = document.querySelector<HTMLElement>(`.inspectres[id*="${id}"] .skill-penalty-line`);
-      if (!el) return false;
-      const rect = el.getBoundingClientRect();
-      return rect.width > 0 && rect.height > 0;
-    }, agentId);
+    const penaltyLineExists = await waitForElementVisible(
+      page,
+      `.inspectres[id*="${agentId}"] .skill-penalty-line`,
+      ELEMENT_WAIT_TIMEOUT,
+    );
     expect(penaltyLineExists).toBe(true);
   });
 });

--- a/foundry/src/__tests__/e2e/franchise-sheet.test.ts
+++ b/foundry/src/__tests__/e2e/franchise-sheet.test.ts
@@ -19,6 +19,7 @@ import {
   waitForNewChatMessage,
   waitForActorFieldChanged,
   waitForActorFieldEquals,
+  getActorSystemField,
 } from "./pages/index.js";
 
 test.describe("FranchiseSheet — roll actions and mission tracker", () => {
@@ -191,20 +192,12 @@ test.describe("FranchiseSheet — debt mode", () => {
     const sheet = await openFranchiseSheet(page, franchiseId);
     await sheet.openTab("notes");
 
-    const before = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { debtMode: boolean })?.debtMode ?? false;
-    }, franchiseId);
+    const before = await getActorSystemField<boolean>(page, franchiseId, "debtMode", false);
 
     await sheet.clickToggleDebtMode();
     await waitForActorFieldChanged(page, franchiseId, "debtMode", before);
 
-    const after = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { debtMode: boolean })?.debtMode ?? false;
-    }, franchiseId);
+    const after = await getActorSystemField<boolean>(page, franchiseId, "debtMode", false);
 
     expect(after).toBe(!before);
 
@@ -241,11 +234,7 @@ test.describe("FranchiseSheet — form-bound inputs", () => {
     await bankInput.press("Tab");
     await waitForActorFieldEquals(page, franchiseId, "bank", 7);
 
-    const bankValue = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { bank: number })?.bank ?? 0;
-    }, franchiseId);
+    const bankValue = await getActorSystemField<number>(page, franchiseId, "bank", 0);
     expect(bankValue).toBe(7);
 
     await page.screenshot({
@@ -266,11 +255,7 @@ test.describe("FranchiseSheet — form-bound inputs", () => {
     await textarea.press("Tab");
     await waitForActorFieldEquals(page, franchiseId, "description", testText);
 
-    const savedDescription = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { description: string })?.description ?? "";
-    }, franchiseId);
+    const savedDescription = await getActorSystemField<string>(page, franchiseId, "description", "");
     expect(savedDescription).toBe(testText);
 
     await page.screenshot({
@@ -290,11 +275,7 @@ test.describe("FranchiseSheet — form-bound inputs", () => {
     await missionGoalInput.press("Tab");
     await waitForActorFieldEquals(page, franchiseId, "missionGoal", 10);
 
-    const missionGoalValue = await page.evaluate((id: string) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(id);
-      return (actor?.system as { missionGoal: number })?.missionGoal ?? 0;
-    }, franchiseId);
+    const missionGoalValue = await getActorSystemField<number>(page, franchiseId, "missionGoal", 0);
     expect(missionGoalValue).toBe(10);
 
     await page.screenshot({

--- a/foundry/src/__tests__/e2e/pages/helpers.ts
+++ b/foundry/src/__tests__/e2e/pages/helpers.ts
@@ -111,14 +111,24 @@ export async function waitForNewChatMessage(
   beforeCount: number,
   timeout = 15_000,
 ): Promise<void> {
-  await page.waitForFunction(
-    (count: number) => {
-      // @ts-expect-error - Foundry runtime global
-      return (globalThis.game?.messages?.size ?? 0) > count;
-    },
-    beforeCount,
-    { timeout },
-  ).catch(() => {});
+  const startTime = Date.now();
+  try {
+    await page.waitForFunction(
+      (count: number) => {
+        // @ts-expect-error - Foundry runtime global
+        return (globalThis.game?.messages?.size ?? 0) > count;
+      },
+      beforeCount,
+      { timeout },
+    );
+  } catch (error) {
+    const elapsed = Date.now() - startTime;
+    // @ts-expect-error - Foundry runtime global
+    const currentCount = (globalThis.game?.messages?.size ?? 0) as number;
+    throw new Error(
+      `waitForNewChatMessage timeout after ${elapsed}ms: expected message count > ${beforeCount}, got ${currentCount}`,
+    );
+  }
 }
 
 /**
@@ -135,22 +145,41 @@ export async function waitForActorFieldChanged(
   previousValue: unknown,
   timeout = 15_000,
 ): Promise<void> {
-  await page.waitForFunction(
-    (args: { id: string; path: string; prev: unknown }) => {
-      // @ts-expect-error - Foundry runtime global
-      const actor = globalThis.game?.actors?.get(args.id);
-      if (!actor) return false;
-      const parts = args.path.split(".");
-      let value: unknown = actor.system;
-      for (const part of parts) {
-        if (value == null || typeof value !== "object") return false;
-        value = (value as Record<string, unknown>)[part];
+  const startTime = Date.now();
+  try {
+    await page.waitForFunction(
+      (args: { id: string; path: string; prev: unknown }) => {
+        // @ts-expect-error - Foundry runtime global
+        const actor = globalThis.game?.actors?.get(args.id);
+        if (!actor) return false;
+        const parts = args.path.split(".");
+        let value: unknown = actor.system;
+        for (const part of parts) {
+          if (value == null || typeof value !== "object") return false;
+          value = (value as Record<string, unknown>)[part];
+        }
+        return value !== args.prev;
+      },
+      { id: actorId, path: fieldPath, prev: previousValue },
+      { timeout },
+    );
+  } catch (error) {
+    const elapsed = Date.now() - startTime;
+    // @ts-expect-error - Foundry runtime global
+    const actor = globalThis.game?.actors?.get(actorId);
+    const parts = fieldPath.split(".");
+    let currentValue: unknown = actor?.system;
+    for (const part of parts) {
+      if (currentValue == null || typeof currentValue !== "object") {
+        currentValue = undefined;
+        break;
       }
-      return value !== args.prev;
-    },
-    { id: actorId, path: fieldPath, prev: previousValue },
-    { timeout },
-  ).catch(() => {});
+      currentValue = (currentValue as Record<string, unknown>)[part];
+    }
+    throw new Error(
+      `waitForActorFieldChanged timeout after ${elapsed}ms on field "${fieldPath}": expected change from ${JSON.stringify(previousValue)}, current value is ${JSON.stringify(currentValue)}`,
+    );
+  }
 }
 
 /**
@@ -167,22 +196,97 @@ export async function waitForActorFieldEquals(
   expectedValue: unknown,
   timeout = 15_000,
 ): Promise<void> {
-  await page.waitForFunction(
-    (args: { id: string; path: string; expected: unknown }) => {
+  const startTime = Date.now();
+  try {
+    await page.waitForFunction(
+      (args: { id: string; path: string; expected: unknown }) => {
+        // @ts-expect-error - Foundry runtime global
+        const actor = globalThis.game?.actors?.get(args.id);
+        if (!actor) return false;
+        const parts = args.path.split(".");
+        let value: unknown = actor.system;
+        for (const part of parts) {
+          if (value == null || typeof value !== "object") return false;
+          value = (value as Record<string, unknown>)[part];
+        }
+        return value === args.expected;
+      },
+      { id: actorId, path: fieldPath, expected: expectedValue },
+      { timeout },
+    );
+  } catch (error) {
+    const elapsed = Date.now() - startTime;
+    // @ts-expect-error - Foundry runtime global
+    const actor = globalThis.game?.actors?.get(actorId);
+    const parts = fieldPath.split(".");
+    let currentValue: unknown = actor?.system;
+    for (const part of parts) {
+      if (currentValue == null || typeof currentValue !== "object") {
+        currentValue = undefined;
+        break;
+      }
+      currentValue = (currentValue as Record<string, unknown>)[part];
+    }
+    throw new Error(
+      `waitForActorFieldEquals timeout after ${elapsed}ms on field "${fieldPath}": expected ${JSON.stringify(expectedValue)}, got ${JSON.stringify(currentValue)}`,
+    );
+  }
+}
+
+/**
+ * Poll until a sheet element is visible, returning the visibility state.
+ * Combines the two-step visibility check pattern into a single helper.
+ */
+export async function waitForElementVisible(
+  page: Page,
+  selector: string,
+  timeout = SHEET_WAIT_TIMEOUT,
+): Promise<boolean> {
+  try {
+    await page.waitForFunction(
+      (sel: string) => {
+        const el = document.querySelector(sel);
+        if (!el) return false;
+        const rect = (el as HTMLElement).getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      },
+      selector,
+      { timeout },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get a typed actor system field by dot-path.
+ * Simplifies the common pattern of accessing actor.system fields with fallback.
+ */
+export async function getActorSystemField<T>(
+  page: Page,
+  actorId: string,
+  fieldPath: string,
+  fallback: T,
+): Promise<T> {
+  const result = await page.evaluate(
+    (args: { id: string; path: string }) => {
       // @ts-expect-error - Foundry runtime global
       const actor = globalThis.game?.actors?.get(args.id);
-      if (!actor) return false;
+      if (!actor) return { found: false, value: undefined as unknown };
       const parts = args.path.split(".");
       let value: unknown = actor.system;
       for (const part of parts) {
-        if (value == null || typeof value !== "object") return false;
+        if (value == null || typeof value !== "object") {
+          return { found: false, value: undefined as unknown };
+        }
         value = (value as Record<string, unknown>)[part];
       }
-      return value === args.expected;
+      return { found: value !== undefined && value !== null, value };
     },
-    { id: actorId, path: fieldPath, expected: expectedValue },
-    { timeout },
-  ).catch(() => {});
+    { id: actorId, path: fieldPath },
+  );
+  return result.found ? (result.value as T) : fallback;
 }
 
 /**

--- a/foundry/src/__tests__/e2e/pages/helpers.ts
+++ b/foundry/src/__tests__/e2e/pages/helpers.ts
@@ -234,14 +234,16 @@ export async function waitForActorFieldEquals(
 }
 
 /**
- * Poll until a sheet element is visible, returning the visibility state.
- * Combines the two-step visibility check pattern into a single helper.
+ * Poll until a sheet element is present and has non-zero size.
+ * Throws with diagnostic context (selector match state, computed display) on timeout
+ * so callers don't have to re-query the DOM to figure out why the wait failed.
  */
 export async function waitForElementVisible(
   page: Page,
   selector: string,
   timeout = SHEET_WAIT_TIMEOUT,
-): Promise<boolean> {
+): Promise<void> {
+  const startTime = Date.now();
   try {
     await page.waitForFunction(
       (sel: string) => {
@@ -253,9 +255,28 @@ export async function waitForElementVisible(
       selector,
       { timeout },
     );
-    return true;
-  } catch {
-    return false;
+  } catch (error) {
+    const elapsed = Date.now() - startTime;
+    const probe = await page.evaluate((sel: string) => {
+      const el = document.querySelector(sel);
+      if (!el) return { exists: false } as const;
+      const rect = (el as HTMLElement).getBoundingClientRect();
+      return {
+        exists: true,
+        tag: el.tagName,
+        classes: el.className,
+        width: rect.width,
+        height: rect.height,
+        display: window.getComputedStyle(el).display,
+      } as const;
+    }, selector);
+    const detail = probe.exists
+      ? `element found (${probe.tag}, classes="${probe.classes}") but has zero size (${probe.width}x${probe.height}, display="${probe.display}")`
+      : `selector matched no elements`;
+    throw new Error(
+      `waitForElementVisible timeout after ${elapsed}ms for selector "${selector}": ${detail}`,
+      { cause: error },
+    );
   }
 }
 
@@ -282,7 +303,9 @@ export async function getActorSystemField<T>(
         }
         value = (value as Record<string, unknown>)[part];
       }
-      return { found: value !== undefined && value !== null, value };
+      // Path traversed successfully — value may legitimately be null, false, "" or 0.
+      // Treat only `undefined` (key absent on system) as missing; null is a real stored value.
+      return { found: value !== undefined, value };
     },
     { id: actorId, path: fieldPath },
   );

--- a/foundry/src/__tests__/e2e/pages/index.ts
+++ b/foundry/src/__tests__/e2e/pages/index.ts
@@ -11,5 +11,7 @@ export {
   waitForNewChatMessage,
   waitForActorFieldChanged,
   waitForActorFieldEquals,
+  waitForElementVisible,
+  getActorSystemField,
   rejoinIfRedirected,
 } from "./helpers.js";


### PR DESCRIPTION
Replaces silent timeout swallowing in three e2e helper functions and the dialog roll-button click with try/catch + diagnostic throws so test failures pinpoint the broken step instead of falling through to unrelated assertion errors.

## What changed

- `waitForNewChatMessage`, `waitForActorFieldChanged`, `waitForActorFieldEquals` (helpers.ts) now throw on timeout with elapsed time + actual vs expected.
- `waitForElementVisible` (new helper) probes the DOM on timeout to report whether the selector matched at all and whether the element had zero size.
- `getActorSystemField<T>` (new helper) collapses the inline `page.evaluate(actor.system)` pattern into one typed call. Treats `undefined` (key absent) as missing, but preserves legitimate `null` / `false` / `""` / `0` values.
- `agent-sheet.test.ts` adopts the new helpers and replaces a silent nested `.catch()` on the dialog roll-button fallback with a try/catch that throws with both selector failures and a `cause` chain.
- `franchise-sheet.test.ts` adopts `getActorSystemField` for four inline patterns.

## Verification

- lint, typecheck, 577 unit tests, 14 E2E tests all pass locally
- Diagnostic improvements verified: e.g. `waitForElementVisible` timeout now reports whether selector matched 0 elements vs matched-but-zero-size

## Deferred

Pre-pr-review surfaced silent `.catch(() => {})` patterns outside this diff — filed as #520 (`rejoinIfRedirected`) and #521 (lifecycle/page-objects/fixtures umbrella).

Closes #515
Closes #516
Closes #517
Closes #518
Closes #519