### PR TITLE
test(e2e): axe-core WCAG AA contrast audit for sheet suites

### DIFF
--- a/.claude/rules/playwright-foundry.md
+++ b/.claude/rules/playwright-foundry.md
@@ -299,7 +299,7 @@ import AxeBuilder from "@axe-core/playwright";
 
 export async function assertSheetAccessibility(page: Page, actorId: string): Promise<void> {
   const results = await new AxeBuilder({ page })
-    .include(`.inspectres[id*="${actorId}"]`)
+    .include(`.application[id*="${actorId}"]`)
     .withTags(["wcag2aa", "wcag21aa"])
     .options({ runOnly: { type: "tag", values: ["color-contrast"] } })
     .analyze();
@@ -312,7 +312,7 @@ export async function assertSheetAccessibility(page: Page, actorId: string): Pro
 }
 ```
 
-**Scope is mandatory.** Always `.include('.inspectres[id*="${actorId}"]')` to bound the audit to our sheet. Auditing the full page surfaces violations in Foundry's own chrome (sidebar, hotbar, notifications) we don't own. The `[id*="..."]` substring match handles Foundry's id-prefixing convention (`t-Actor-<id>`).
+**Scope: outer ApplicationV2 wrapper, not the inner `.inspectres` body.** Always `.include('.application[id*="${actorId}"]')`. The window chrome (title bar, header buttons, controls) is rendered by Foundry *outside* our `.inspectres` div. Most of our UI is ApplicationV2 (sheets, dialogs) and our theme restyles the entire window — so the audit must cover it. Scoping by `[id*="${actorId}"]` keeps the audit on this actor's window and excludes the sidebar/hotbar/notifications we don't own.
 
 **Tags:** `wcag2aa` + `wcag21aa` is the minimum. Adding `wcag2aaa` is fine for stricter coverage if the sheet currently passes.
 

--- a/.claude/rules/playwright-foundry.md
+++ b/.claude/rules/playwright-foundry.md
@@ -288,6 +288,38 @@ A test that passes only on retry is a broken test. Treat it the same as a test t
 | Dialog click fails intermittently | Dialog not fully rendered when clicked | `waitForFunction` checking `getBoundingClientRect` before clicking |
 | Second action fails after first | Sheet re-rendered between steps | Re-query elements after any actor update |
 
+## Accessibility Testing
+
+Every sheet E2E suite (agent, franchise, mission tracker, etc.) must include an `accessibility — all tabs pass WCAG AA contrast` test. The test opens the sheet, iterates each tab, and calls `assertSheetAccessibility(page, actorId)` after each tab switch.
+
+The helper lives in `pages/helpers.ts` and uses `@axe-core/playwright`:
+
+```typescript
+import AxeBuilder from "@axe-core/playwright";
+
+export async function assertSheetAccessibility(page: Page, actorId: string): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .include(`.inspectres[id*="${actorId}"]`)
+    .withTags(["wcag2aa", "wcag21aa"])
+    .options({ runOnly: { type: "tag", values: ["color-contrast"] } })
+    .analyze();
+  if (results.violations.length > 0) {
+    const detail = results.violations
+      .flatMap((v) => v.nodes.map((n) => `  [${v.id}] ${n.html}\n    ${v.help}`))
+      .join("\n");
+    throw new Error(`Accessibility violations in sheet ${actorId}:\n${detail}`);
+  }
+}
+```
+
+**Scope is mandatory.** Always `.include('.inspectres[id*="${actorId}"]')` to bound the audit to our sheet. Auditing the full page surfaces violations in Foundry's own chrome (sidebar, hotbar, notifications) we don't own. The `[id*="..."]` substring match handles Foundry's id-prefixing convention (`t-Actor-<id>`).
+
+**Tags:** `wcag2aa` + `wcag21aa` is the minimum. Adding `wcag2aaa` is fine for stricter coverage if the sheet currently passes.
+
+**Runs limited to `color-contrast`.** Other audits (landmark roles, form labels) generate noise from Foundry's chrome that bleeds through DOM relationships even when scoped. Color-contrast is the most user-visible accessibility failure and stays inside the included subtree.
+
+**pre-pr-review P1 finding:** any new sheet E2E suite that lacks an accessibility test block. Adding a new sheet means adding accessibility coverage in the same PR.
+
 ## Local Validation Before Push
 
 **HARD REQUIREMENT — GitHub Actions minutes are limited.**

--- a/foundry/package-lock.json
+++ b/foundry/package-lock.json
@@ -8,6 +8,7 @@
       "name": "inspectres-vtt",
       "version": "0.2.0",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@foundryvtt/foundryvtt-cli": "^3.0.3",
         "@playwright/test": "^1.59.1",
         "@types/node": "^24.12.2",
@@ -75,6 +76,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -2011,6 +2025,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/base64-js": {

--- a/foundry/package.json
+++ b/foundry/package.json
@@ -22,6 +22,7 @@
     "node": ">=22"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@foundryvtt/foundryvtt-cli": "^3.0.3",
     "@playwright/test": "^1.59.1",
     "@types/node": "^24.12.2",

--- a/foundry/scripts/run-e2e.sh
+++ b/foundry/scripts/run-e2e.sh
@@ -54,7 +54,9 @@ else
 
   # Foundry holds an exclusive lock while running; if a previous run was killed
   # uncleanly the lock remains and prevents the next container from starting.
-  rm -f "${DATA_DIR}/Config/options.json.lock"
+  # Depending on the Foundry version + filesystem, the lock can be either a
+  # regular file or a directory, so handle both with `rm -rf`.
+  rm -rf "${DATA_DIR}/Config/options.json.lock"
 fi
 
 if [[ "${KEEP_CONTAINER:-0}" != "1" && "${KEEP_DATA:-0}" != "1" ]]; then

--- a/foundry/src/__tests__/e2e/agent-sheet.test.ts
+++ b/foundry/src/__tests__/e2e/agent-sheet.test.ts
@@ -14,6 +14,7 @@ import {
   waitForActorFieldChanged,
   waitForElementVisible,
   getActorSystemField,
+  assertSheetAccessibility,
 } from "./pages/index.js";
 
 const SKILL_NAMES = ["academics", "athletics", "technology", "contact"] as const;
@@ -195,5 +196,25 @@ test.describe("AgentSheet — conditional UI paths", () => {
       `.inspectres[id*="${agentId}"] .skill-penalty-line`,
       ELEMENT_WAIT_TIMEOUT,
     );
+  });
+});
+
+test.describe("AgentSheet — accessibility", () => {
+  let agentId: string;
+
+  test.beforeEach(async ({ page }) => {
+    agentId = await createActor(page, "agent", `E2E-agent-a11y-${Date.now()}`);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await deleteActor(page, agentId);
+  });
+
+  test("all tabs pass WCAG AA contrast", async ({ page }) => {
+    const sheet = await openAgentSheet(page, agentId);
+    for (const tab of ["stats", "notes"] as const) {
+      await sheet.openTab(tab);
+      await assertSheetAccessibility(page, agentId);
+    }
   });
 });

--- a/foundry/src/__tests__/e2e/fixtures.ts
+++ b/foundry/src/__tests__/e2e/fixtures.ts
@@ -25,8 +25,15 @@ async function dismissStartupNotifications(page: Page): Promise<void> {
   // permanent <li class="notification"> elements with no close button — they
   // can only be removed via DOM. Don't press ESC: it toggles the game menu
   // and opens an overlay that intercepts subsequent clicks.
+  //
+  // Tour overlays (`.tour-overlay`) are suppressed in globalSetup by persisting
+  // tour completion to core.tourProgress. We still strip stragglers from the DOM
+  // here in case a re-render slipped one through.
   await page.evaluate(() => {
     for (const el of document.querySelectorAll(".notification.permanent")) {
+      el.remove();
+    }
+    for (const el of document.querySelectorAll(".tour-overlay, .tour")) {
       el.remove();
     }
   });

--- a/foundry/src/__tests__/e2e/franchise-sheet.test.ts
+++ b/foundry/src/__tests__/e2e/franchise-sheet.test.ts
@@ -22,6 +22,7 @@ import {
   waitForActorFieldEquals,
   waitForElementVisible,
   getActorSystemField,
+  assertSheetAccessibility,
 } from "./pages/index.js";
 
 test.describe("FranchiseSheet — roll actions and mission tracker", () => {
@@ -256,5 +257,25 @@ test.describe("FranchiseSheet — form-bound inputs", () => {
     expect(missionGoalValue).toBe(10);
 
     await safeScreenshot(page, "test-results/e2e-screenshots/franchise-09-mission-goal.png");
+  });
+});
+
+test.describe("FranchiseSheet — accessibility", () => {
+  let franchiseId: string;
+
+  test.beforeEach(async ({ page }) => {
+    franchiseId = await createActor(page, "franchise", `E2E-franchise-a11y-${Date.now()}`);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await deleteActor(page, franchiseId);
+  });
+
+  test("all tabs pass WCAG AA contrast", async ({ page }) => {
+    const sheet = await openFranchiseSheet(page, franchiseId);
+    for (const tab of ["stats", "notes"] as const) {
+      await sheet.openTab(tab);
+      await assertSheetAccessibility(page, franchiseId);
+    }
   });
 });

--- a/foundry/src/__tests__/e2e/global-setup.ts
+++ b/foundry/src/__tests__/e2e/global-setup.ts
@@ -243,6 +243,49 @@ async function joinAsUser(page: Page, username: string, timeouts = DEFAULT_JOIN_
     undefined,
     { timeout: timeouts.ready },
   );
+
+  // Mark every registered tour as completed and persist to the user. On a fresh
+  // world Foundry auto-launches first-time tours (e.g. "welcome") which render
+  // a `.tour-overlay` that intercepts pointer events and breaks subsequent clicks
+  // mid-test. Persist completion to the per-user core.tourProgress setting so
+  // tours never auto-launch in per-test contexts.
+  //
+  // Wrapped in a 10s timeout: tour.complete() can occasionally hang waiting for
+  // its own DOM/render cycle. We don't need to await individual completions —
+  // setting tourProgress directly is enough to suppress future auto-launches.
+  await page.evaluate(async () => {
+    const TIMEOUT_MS = 10_000;
+    interface FoundryTour { id?: string; namespace?: string; exit?: () => void }
+    interface FoundryTours { active?: FoundryTour | null; values?: () => Iterable<FoundryTour> }
+    interface FoundrySettings { get: (n: string, k: string) => unknown; set: (n: string, k: string, v: unknown) => Promise<unknown> }
+    interface FoundryGame { tours?: FoundryTours; settings?: FoundrySettings }
+    const g = globalThis as { game?: FoundryGame };
+
+    const work = (async () => {
+      try { g.game?.tours?.active?.exit?.(); } catch { /* tour API may be absent */ }
+      const tours = g.game?.tours;
+      const progress: Record<string, string> = {};
+      if (tours?.values) {
+        for (const tour of tours.values()) {
+          const key = tour.namespace && tour.id ? `${tour.namespace}.${tour.id}` : tour.id;
+          if (key) progress[key] = "completed";
+        }
+      }
+      try {
+        if (g.game?.settings) {
+          await g.game.settings.set("core", "tourProgress", progress);
+        }
+      } catch { /* setting may not exist on older Foundry */ }
+      for (const el of document.querySelectorAll(".tour-overlay, .tour")) {
+        el.remove();
+      }
+    })();
+
+    await Promise.race([
+      work,
+      new Promise((resolve) => setTimeout(resolve, TIMEOUT_MS)),
+    ]);
+  });
 }
 
 async function launchAndJoin(page: Page, baseUrl: string, majorVersion: number): Promise<void> {

--- a/foundry/src/__tests__/e2e/pages/AgentSheetPage.ts
+++ b/foundry/src/__tests__/e2e/pages/AgentSheetPage.ts
@@ -49,8 +49,12 @@ export class AgentSheetPage {
 
   /** Click a tab by its data-tab value and wait for the panel to become visible. */
   async openTab(tabName: string): Promise<void> {
+    // force: true bypasses overlay-intercept checks. Foundry first-time tours
+    // can re-render `.tour-overlay` between tab clicks; globalSetup marks them
+    // completed but this guards against re-launch races during the test.
     await this.page.click(
       `${this.sheetSelector()} [role="tab"][data-tab="${tabName}"]`,
+      { force: true },
     );
     await this.page.waitForFunction(
       (args: { actorId: string; tabName: string }) => {

--- a/foundry/src/__tests__/e2e/pages/FranchiseSheetPage.ts
+++ b/foundry/src/__tests__/e2e/pages/FranchiseSheetPage.ts
@@ -30,8 +30,12 @@ export class FranchiseSheetPage {
   }
 
   async openTab(tabName: string): Promise<void> {
+    // force: true bypasses overlay-intercept checks. Foundry first-time tours
+    // can re-render `.tour-overlay` between tab clicks; globalSetup marks them
+    // completed but this guards against re-launch races during the test.
     await this.page.click(
       `${this.sheetSelector()} [role="tab"][data-tab="${tabName}"]`,
+      { force: true },
     );
     await this.page.waitForFunction(
       (args: { actorId: string; tabName: string }) => {

--- a/foundry/src/__tests__/e2e/pages/helpers.ts
+++ b/foundry/src/__tests__/e2e/pages/helpers.ts
@@ -392,11 +392,15 @@ export async function rejoinIfRedirected(page: Page, workerUsername: string): Pr
 }
 
 /**
- * Run an axe-core WCAG AA color-contrast audit scoped to this sheet only.
+ * Run an axe-core WCAG AA color-contrast audit scoped to this sheet's
+ * ApplicationV2 window, including the window chrome (title bar, header buttons)
+ * that Foundry renders outside our `.inspectres` body.
  *
- * Scope is critical: `.include()` keeps the audit inside our sheet element, so
- * Foundry's own chrome (sidebar, hotbar, notifications) doesn't generate noise.
- * Auditing the full page would flag third-party UI we don't own.
+ * Scope: `.application[id*="${actorId}"]` matches the outer V2 wrapper whose id
+ * embeds the actor id. This catches violations in both our theme and any
+ * Foundry chrome we restyle via CSS variable overrides — which is the whole
+ * window-app for ApplicationV2 sheets. Auditing the full page would surface
+ * sidebar/hotbar/notification violations we don't own.
  *
  * Throws with a structured violation summary if any contrast issue is found.
  */
@@ -405,7 +409,7 @@ export async function assertSheetAccessibility(
   actorId: string,
 ): Promise<void> {
   const results = await new AxeBuilder({ page })
-    .include(`.inspectres[id*="${actorId}"]`)
+    .include(`.application[id*="${actorId}"]`)
     .withTags(["wcag2aa", "wcag21aa"])
     .options({ runOnly: { type: "tag", values: ["color-contrast"] } })
     .analyze();

--- a/foundry/src/__tests__/e2e/pages/helpers.ts
+++ b/foundry/src/__tests__/e2e/pages/helpers.ts
@@ -1,3 +1,4 @@
+import AxeBuilder from "@axe-core/playwright";
 import type { Page } from "@playwright/test";
 import type { ConsoleBuffer } from "../console-capture.js";
 import { AgentSheetPage } from "./AgentSheetPage.js";
@@ -387,5 +388,32 @@ export async function rejoinIfRedirected(page: Page, workerUsername: string): Pr
     );
   } catch (err) {
     rethrow("wait for game.ready", err);
+  }
+}
+
+/**
+ * Run an axe-core WCAG AA color-contrast audit scoped to this sheet only.
+ *
+ * Scope is critical: `.include()` keeps the audit inside our sheet element, so
+ * Foundry's own chrome (sidebar, hotbar, notifications) doesn't generate noise.
+ * Auditing the full page would flag third-party UI we don't own.
+ *
+ * Throws with a structured violation summary if any contrast issue is found.
+ */
+export async function assertSheetAccessibility(
+  page: Page,
+  actorId: string,
+): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .include(`.inspectres[id*="${actorId}"]`)
+    .withTags(["wcag2aa", "wcag21aa"])
+    .options({ runOnly: { type: "tag", values: ["color-contrast"] } })
+    .analyze();
+
+  if (results.violations.length > 0) {
+    const detail = results.violations
+      .flatMap((v) => v.nodes.map((n) => `  [${v.id}] ${n.html}\n    ${v.help}`))
+      .join("\n");
+    throw new Error(`Accessibility violations in sheet ${actorId}:\n${detail}`);
   }
 }

--- a/foundry/src/__tests__/e2e/pages/index.ts
+++ b/foundry/src/__tests__/e2e/pages/index.ts
@@ -15,4 +15,5 @@ export {
   getActorSystemField,
   rejoinIfRedirected,
   wrapDiagnosticError,
+  assertSheetAccessibility,
 } from "./helpers.js";


### PR DESCRIPTION
Closes #511

## Summary

- Adds `@axe-core/playwright` v4.11.3 and an `assertSheetAccessibility(page, actorId)` helper that runs axe color-contrast against the outer ApplicationV2 wrapper for a given actor's sheet.
- New per-suite accessibility tests in `agent-sheet.test.ts` and `franchise-sheet.test.ts` iterate `stats` + `notes` tabs and call the helper after each switch.
- Documents the pattern in `.claude/rules/playwright-foundry.md` ("Accessibility Testing") so future sheet suites add coverage in the same PR.

## Scope

The helper scopes by `.application[id*="${actorId}"]` (not the inner `.inspectres` body) because most of our UI is ApplicationV2 and our theme restyles the entire window — the title bar, header buttons, and window chrome were previously excluded from the audit. Runs are limited to `color-contrast` to avoid noise from Foundry chrome bleeding through ARIA relationships.

## Side fixes (pulled in while validating the suite end-to-end)

- **Tour suppression in `global-setup`**: persists every registered tour to `core.tourProgress = "completed"` after `game.ready`. Foundry first-time tours render `.tour-overlay` which intercepts pointer events and breaks mid-test clicks on a fresh world. Wrapped in a 10s `Promise.race` timeout so a hung `tour.complete()` can't block setup.
- **`openTab` uses `force: true`** on Agent + Franchise page objects as a belt-and-suspenders guard if a tour re-renders mid-test.
- **`run-e2e.sh`**: lock cleanup switched to recursive removal — Foundry sometimes creates `options.json.lock` as a directory, and the non-recursive form failed under `set -euo pipefail`.

## Test plan

- [x] `caffeinate -di bash scripts/run-e2e.sh -- --grep "all tabs pass WCAG AA contrast"` — 2 passed (26s) on fresh world.
- [x] `npx slop-scan scan . --lint` — no new findings in the diff.
- [x] `npm run quality` clean before push.