### PR TITLE
refactor(css): consolidate rgba literals + drop input theming !important

### DIFF
--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -93,9 +93,10 @@
   }
 
   /* Header h1/input rules need higher specificity than Foundry's default
-     window-content input styling. Compounding `&.inspectres-header` adds
-     one class to the selector chain (0,3,1 → 0,4,1) without changing
-     markup, letting us drop `!important` from theming rules. See issue #560. */
+     window-content input styling. Compounding `&.inspectres-header` doubles
+     the header class in the selector chain, bumping us comfortably past
+     Foundry's `.window-content input` (0,2,1) so we can drop `!important`
+     from theming rules. See issue #560. */
   &.inspectres-header h1 {
     margin: 0 0 0.2rem;
     font-size: 1rem;

--- a/foundry/src/styles/inspectres.css
+++ b/foundry/src/styles/inspectres.css
@@ -82,7 +82,7 @@
     width: 52px;
     height: 52px;
     border-radius: var(--inspectres-radius-lg);
-    border: 2px solid rgba(255, 255, 255, 0.35);
+    border: 2px solid var(--inspectres-header-portrait-border);
     object-fit: cover;
     flex-shrink: 0;
   }
@@ -92,24 +92,28 @@
     min-width: 0;
   }
 
-  h1 {
+  /* Header h1/input rules need higher specificity than Foundry's default
+     window-content input styling. Compounding `&.inspectres-header` adds
+     one class to the selector chain (0,3,1 → 0,4,1) without changing
+     markup, letting us drop `!important` from theming rules. See issue #560. */
+  &.inspectres-header h1 {
     margin: 0 0 0.2rem;
     font-size: 1rem;
     line-height: 1;
-    color: white;
+    color: var(--inspectres-white);
 
     input[type="text"] {
       width: 100%;
       font-size: 1.05rem;
       font-weight: 700;
       letter-spacing: 0.02em;
-      color: white !important;
-      background: rgba(255, 255, 255, 0.12) !important;
-      border-color: rgba(255, 255, 255, 0.25) !important;
+      color: var(--inspectres-white);
+      background: var(--inspectres-header-input-bg);
+      border-color: var(--inspectres-header-input-border);
       padding: 0.2rem 0.4rem;
 
-      &::placeholder { color: rgba(255, 255, 255, 0.5); }
-      &:focus { border-color: rgba(255, 255, 255, 0.6) !important; box-shadow: none; }
+      &::placeholder { color: var(--inspectres-header-placeholder); }
+      &:focus { border-color: var(--inspectres-header-input-border-focus); box-shadow: none; }
     }
   }
 
@@ -119,7 +123,7 @@
     font-weight: 600;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--inspectres-header-text-muted);
   }
 
   /* Franchise header has no portrait — h1 must stretch to fill available width */
@@ -861,6 +865,12 @@ details > summary {
 
 /* ─── DialogV2 create-document dialog ──────────────────────────────────── */
 
+/* Foundry V13's CreateDocumentDialog sizes itself by writing an explicit pixel
+   height to the .application element's inline style after first layout. The
+   resulting box is too short for our document-type selector (clips the form).
+   Inline styles can only be defeated by !important — this isn't a theming
+   override, it's a sizing reset against a Foundry-computed inline value. See
+   issue #562. */
 .application:has(form.dialog-form) {
   height: auto !important;
 }

--- a/foundry/src/styles/theme/chat.css
+++ b/foundry/src/styles/theme/chat.css
@@ -22,7 +22,7 @@
   border-left-color: var(--inspectres-green-dark);
   background: linear-gradient(
     90deg,
-    rgba(56, 180, 74, 0.05) 0%,
+    var(--inspectres-green-overlay-faint) 0%,
     var(--inspectres-white) 20%
   );
 }
@@ -126,7 +126,7 @@
 }
 
 .inspectres .chat-message.system .message-header {
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--inspectres-black-overlay-faint);
 }
 
 .inspectres .chat-message.system .message-sender {
@@ -221,7 +221,7 @@
   border-left-color: var(--inspectres-green-dark);
   background: linear-gradient(
     90deg,
-    rgba(56, 180, 74, 0.05) 0%,
+    var(--inspectres-green-overlay-faint) 0%,
     var(--inspectres-white) 20%
   );
 }
@@ -248,7 +248,7 @@
   border-left-color: var(--inspectres-green-dark);
   background: linear-gradient(
     90deg,
-    rgba(56, 180, 74, 0.08) 0%,
+    var(--inspectres-green-overlay-soft) 0%,
     var(--inspectres-white) 20%
   );
 }
@@ -329,7 +329,7 @@
 }
 
 .inspectres .inline-roll-card.good {
-  background: rgba(56, 180, 74, 0.15);
+  background: var(--inspectres-green-overlay-medium);
   border-color: var(--inspectres-green-dark);
   color: var(--inspectres-green-dark);
 }
@@ -420,7 +420,7 @@
 }
 
 .inspectres .roll-modifier.positive {
-  background: rgba(56, 180, 74, 0.2);
+  background: var(--inspectres-green-overlay-strong);
   color: var(--inspectres-green-dark);
 }
 
@@ -430,6 +430,6 @@
 }
 
 .inspectres .roll-modifier.neutral {
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--inspectres-black-overlay-soft);
   color: var(--inspectres-text-primary);
 }

--- a/foundry/src/styles/theme/controls.css
+++ b/foundry/src/styles/theme/controls.css
@@ -391,7 +391,7 @@
 .inspectres textarea.success,
 .inspectres select.success {
   border-color: var(--inspectres-green-dark);
-  box-shadow: 0 0 0 2px rgba(56, 180, 74, 0.1);
+  box-shadow: 0 0 0 2px var(--inspectres-focus-ring-light);
 }
 
 /* Warning state */

--- a/foundry/src/styles/theme/utilities.css
+++ b/foundry/src/styles/theme/utilities.css
@@ -31,7 +31,7 @@
 
 .inspectres .btn-primary:active {
   background: var(--inspectres-button-bg-active);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 2px 4px var(--inspectres-black-overlay-medium);
 }
 
 .inspectres .btn-primary:disabled {

--- a/foundry/src/styles/theme/variables.css
+++ b/foundry/src/styles/theme/variables.css
@@ -29,6 +29,14 @@
   --inspectres-orange-darker: #cc7000; /* die failure border, accent on orange surfaces */
   --inspectres-orange-darkest: #994c00; /* danger button :active state */
 
+  /* RGB components — for variable-alpha overlay construction via rgba().
+     Mirrors each base color above. Keep in sync with the hex value. */
+  --inspectres-white-rgb: 255, 255, 255;
+  --inspectres-black-rgb: 0, 0, 0;
+  --inspectres-green-dark-rgb: 56, 180, 74;
+  --inspectres-orange-bright-rgb: 255, 140, 0;   /* base for orange overlays */
+  --inspectres-warn-amber-rgb: 255, 193, 7;      /* base for warn/amber overlays */
+
   /* --- SEMANTIC TOKENS (Purpose-driven, map palette to use cases) --- */
 
   /* Backgrounds */
@@ -70,9 +78,9 @@
   --inspectres-status-error: var(--inspectres-orange);
 
   /* Shadows & Depth */
-  --inspectres-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --inspectres-shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
-  --inspectres-shadow-lg: 0 4px 8px rgba(0, 0, 0, 0.15);
+  --inspectres-shadow-sm: 0 1px 2px rgba(var(--inspectres-black-rgb), 0.05);
+  --inspectres-shadow-md: 0 2px 4px rgba(var(--inspectres-black-rgb), 0.1);
+  --inspectres-shadow-lg: 0 4px 8px rgba(var(--inspectres-black-rgb), 0.15);
 
   /* Spacing (optional, for consistency) */
   --inspectres-space-xs: 4px;
@@ -91,16 +99,16 @@
   );
 
   /* Focus ring (semi-transparent green for input focus states) */
-  --inspectres-focus-ring: rgba(56, 180, 74, 0.2);
+  --inspectres-focus-ring: rgba(var(--inspectres-green-dark-rgb), 0.2);
 
   /* Orange overlay (semi-transparent orange for death mode background) */
-  --inspectres-orange-overlay: rgba(255, 140, 0, 0.05);
+  --inspectres-orange-overlay: rgba(var(--inspectres-orange-bright-rgb), 0.05);
 
   /* Orange overlay darker (for death mode header background) */
-  --inspectres-orange-overlay-dark: rgba(255, 140, 0, 0.1);
+  --inspectres-orange-overlay-dark: rgba(var(--inspectres-orange-bright-rgb), 0.1);
 
   /* Warn (yellow) overlays for roll outcomes */
-  --inspectres-warn-overlay-light: rgba(255, 193, 7, 0.05);
+  --inspectres-warn-overlay-light: rgba(var(--inspectres-warn-amber-rgb), 0.05);
 
   /* --- V2 SHEET COMPATIBILITY (used in inspectres.css) --- */
 
@@ -135,7 +143,7 @@
   --inspectres-warn-bg: #fffacd;
   --inspectres-warn-border: #f0e68c;
   --inspectres-warn-text: #333333;
-  --inspectres-warn-overlay-medium: rgba(255, 193, 7, 0.15);
+  --inspectres-warn-overlay-medium: rgba(var(--inspectres-warn-amber-rgb), 0.15);
 
   /* Death/Status colors */
   --inspectres-dead-bg: #ffe8e8;
@@ -148,10 +156,29 @@
   --inspectres-inactive: #e8e8e8;
 
   /* Warn overlay variants */
-  --inspectres-warn-overlay-dark: rgba(255, 193, 7, 0.15);
+  --inspectres-warn-overlay-dark: rgba(var(--inspectres-warn-amber-rgb), 0.15);
 
   /* Green overlay light (for recovering status background) */
-  --inspectres-focus-ring-light: rgba(56, 180, 74, 0.1);
+  --inspectres-focus-ring-light: rgba(var(--inspectres-green-dark-rgb), 0.1);
+
+  /* Green overlays for inline roll cards and toast variants */
+  --inspectres-green-overlay-faint: rgba(var(--inspectres-green-dark-rgb), 0.05);   /* roll card gradients, toast info */
+  --inspectres-green-overlay-soft: rgba(var(--inspectres-green-dark-rgb), 0.08);    /* toast success */
+  --inspectres-green-overlay-medium: rgba(var(--inspectres-green-dark-rgb), 0.15);  /* inline-roll-card.good background */
+  --inspectres-green-overlay-strong: rgba(var(--inspectres-green-dark-rgb), 0.2);   /* positive roll modifier background */
+
+  /* Black overlays — neutral darkening/scrim */
+  --inspectres-black-overlay-faint: rgba(var(--inspectres-black-rgb), 0.05);    /* system message header */
+  --inspectres-black-overlay-soft: rgba(var(--inspectres-black-rgb), 0.1);      /* neutral roll modifier background */
+  --inspectres-black-overlay-medium: rgba(var(--inspectres-black-rgb), 0.15);   /* inset shadow on active buttons */
+
+  /* White header overlays — semi-transparent white for inputs against gradient header background */
+  --inspectres-header-input-bg: rgba(var(--inspectres-white-rgb), 0.12);
+  --inspectres-header-input-border: rgba(var(--inspectres-white-rgb), 0.25);
+  --inspectres-header-input-border-focus: rgba(var(--inspectres-white-rgb), 0.6);
+  --inspectres-header-portrait-border: rgba(var(--inspectres-white-rgb), 0.35);
+  --inspectres-header-placeholder: rgba(var(--inspectres-white-rgb), 0.5);
+  --inspectres-header-text-muted: rgba(var(--inspectres-white-rgb), 0.6);
 
   /* Select dropdown SVG icon (down chevron) */
   --inspectres-select-arrow: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3e%3cpath fill='%23000' d='M1 1l5 5 5-5'/%3e%3c/svg%3e");


### PR DESCRIPTION
## Summary

Three small CSS theming-hygiene refactors bundled together because they share files and concepts (`.claude/rules/foundry-theming.md`).

- **#561** — Adds RGB-component variables (`--inspectres-white-rgb`, `--inspectres-black-rgb`, `--inspectres-green-dark-rgb`, `--inspectres-orange-bright-rgb`, `--inspectres-warn-amber-rgb`) plus semantic overlay vars (`--inspectres-green-overlay-{faint,soft,medium,strong}`, `--inspectres-black-overlay-*`, `--inspectres-header-*`). All `rgba(<digit>` literals outside `variables.css` are now references.
- **#560** — Drops four `!important` declarations from the gradient-header input theming. Compound `&.inspectres-header` raises selector specificity past Foundry's `.window-content input` rules, so the overrides apply without `!important`. White-on-gradient overlays moved into named theme variables.
- **#562** — Replaces the lone `rgba()` in `controls.css` with `--inspectres-focus-ring-light`. The remaining `!important` on `.application:has(form.dialog-form)` is now documented: Foundry V13 writes an inline pixel height on `CreateDocumentDialog` that can only be defeated by `!important`. It's a sizing reset, not a theming override.

Verified: no `rgba(<digit>` literals remain anywhere in `foundry/src/styles/`. Only one `!important` remains (the documented dialog sizing workaround).

## Test plan

- [x] `npm run quality` passes (lint + tsc + 616 tests)
- [ ] Manual visual check: agent + franchise sheet gradient header — name input still readable on green background, focus state visible
- [ ] Manual visual check: chat roll cards (good/partial/bad) — gradient backgrounds unchanged
- [ ] Manual visual check: toast variants (info/success/warn/error) — backgrounds unchanged
- [ ] Manual visual check: inline roll cards + roll modifier pills — positive/neutral coloring unchanged
- [ ] Manual visual check: CreateDocumentDialog still renders without clipping

Closes #560
Closes #561
Closes #562
Closes #574