### PR TITLE
refactor: chat consolidation + roll-executor split + dev logging (#576)

### DIFF
--- a/.claude/rules/no-bug-left-behind.md
+++ b/.claude/rules/no-bug-left-behind.md
@@ -1,0 +1,73 @@
+# No Bug Left Behind
+
+Companion to CLAUDE.md's "no bug or feature left behind" principle. Codifies how that principle interacts with PR review workflows.
+
+## Core Rule
+
+If a scanner, linter, type checker, audit agent, or manual review surfaces a finding **in a file the current branch already touches**, fix it in the current branch. Do not defer it under the label "pre-existing."
+
+This applies regardless of whether the finding's root cause predates the branch. The branch is editing the file; the next reviewer is reading the file; the next bug report will land on the file. Fix it now.
+
+## When Deferral Is Legitimate
+
+Deferral via GitHub issue is only legitimate when one of these holds:
+
+1. **Architectural redesign required.** Fix changes the shape of a public API, data model, or cross-cutting abstraction that needs design discussion first.
+2. **Out-of-scope file.** Finding is in a file the current branch does NOT touch. (Even then, prefer filing an issue immediately over silently ignoring.)
+3. **External dependency blocks fix.** Awaiting upstream library, infra change, or third-party fix.
+4. **Genuinely large effort.** Multi-day investigation that would derail the current ticket. Document the effort estimate when deferring.
+
+"This is a pre-existing issue, not introduced by my diff" is **not** a legitimate reason. Neither is "this is out of scope of the original ticket" when the file is in the diff.
+
+## Mandatory Scans
+
+These scans' P1/P2 findings are not advisory — they are gate criteria for any PR that touches the relevant files:
+
+- `npx slop-scan scan . --lint`
+- `oxlint` (via `npm run lint`)
+- `tsc --noEmit` (via `npm run check`)
+- `vitest` (via `npm run test`)
+- pre-pr-review subagent findings (security-audit, variant-bug-hunter, code-reviewer, etc.)
+
+If any of these flag a file in the branch's diff, the finding gets fixed before the PR opens, not deferred.
+
+## Workflow Integration
+
+### pre-pr-review Step 6 (fix loop)
+
+For every P1/P2 finding in the consolidated list:
+
+1. Is the file in the branch's diff (`git diff --name-only $BASE...HEAD`)? → **Fix now.**
+2. Is the file outside the diff but the finding is small (<30 min)? → **Fix now**, mention in commit message.
+3. Otherwise → file a GitHub issue with priority + area + type labels, link from PR body.
+
+### pre-pr-review Step 7 (deferred work)
+
+Before marking anything as deferred, verify: did I call this "pre-existing" or "out of scope" as a shortcut? If yes, move it back to Step 6 and fix it.
+
+The deferred section of the PR body should be empty most of the time. Non-empty deferred lists need explicit justification per item.
+
+### ship-issue Step 5 (implement)
+
+If you discover a bug or smell while implementing the ticket, and the bug is in a file you're editing: fix it in the same branch. Reference it in the commit message but don't open a separate issue unless the user explicitly asked.
+
+## Anti-Patterns
+
+| Never | Do this |
+|-------|---------|
+| "Deferred as pre-existing" | Fix it; the file is in your diff |
+| "Out of scope of the ticket" (file is in diff) | Fix it; scope follows touched files, not the ticket title |
+| Filing an issue for a 5-line fix in your diff | Just make the fix; one commit, one PR |
+| Silently ignoring a scanner finding | Either fix it or file an issue with rationale |
+| Marking a finding "false positive" without justification in PR body | Document why; reviewers should see your reasoning |
+| Letting CLAUDE.md "no bug left behind" lose to pre-pr-review's "scope" instinct | CLAUDE.md wins; scope expands to cover the finding |
+
+## Why
+
+The user has corrected this behavior multiple times. The "pre-existing" deferral pattern:
+- Inflates issue backlogs with paper cuts that never get prioritized
+- Lets known smells calcify in actively edited code
+- Sends the wrong signal to future contributors ("we know about it but won't fix it")
+- Wastes review cycles re-discovering the same finding on the next PR
+
+Fixing in-branch costs a few extra minutes. Deferring costs forever.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Patterns split by domain. Each file scoped to specific paths:
 | `enums-and-magic-strings.md` | `**/*.ts` `**/*.hbs` | Avoid magic strings; prefer enums, especially templates |
 | `temporary-work.md` | `.tmp/**` | Scratch files, logs, reports, build artifacts |
 | `changelog.md` | `CHANGELOG.md` | Semver & changelog format |
+| `no-bug-left-behind.md` | all | "Pre-existing" is not a deferral excuse — fix scanner findings in files the branch touches |
 
 Auto-loaded by Claude Code. Supplement main CLAUDE.md.
 

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -9,6 +9,7 @@ import { executeSkillRoll, executeStressRoll, SKILL_NAMES, type SkillName } from
 import { agentSystemData } from "./agent-system-data.js";
 import { findFranchiseActor, franchiseSystemData } from "../franchise/franchise-utils.js";
 import { handleActionError } from "../utils/ui-errors.js";
+import { getDevLogger } from "../utils/dev-logger.js";
 import { activateTabs } from "../utils/sheet-tabs.js";
 import { getOrCreateListenerController } from "../utils/listener-cleanup.js";
 import { computeRecoveryStatus, getCurrentDay } from "./recovery-utils.js";
@@ -71,7 +72,7 @@ async function buildStressRollDialog(agent: Actor): Promise<void> {
         callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
           const form = dialog.element.querySelector("form") as HTMLFormElement | null;
           if (!form) {
-            console.error("buildStressRollDialog: form element not found in dialog");
+            getDevLogger().error("agent-sheet", "buildStressRollDialog: form element not found in dialog");
             return null;
           }
           const data = new FormData(form);
@@ -190,13 +191,11 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
         //   Prevent >1 weird per group
         // }
         void updateDocument(this.actor, { "system.isWeird": target.checked }).catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          console.error("Failed to toggle weird status for agent", {
+          getDevLogger().error("agent-sheet", "Failed to toggle weird status for agent", {
             actorId: this.actor.id,
             actorName: this.actor.name,
             targetValue: target.checked,
-            error: err,
-            errorMessage: message,
+            error: err instanceof Error ? err.message : String(err),
           });
           handleActionError(err, "Failed to toggle weird status", "INSPECTRES.ErrorUpdateFailed", "Failed to update actor data");
         });
@@ -208,13 +207,11 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
       el.addEventListener("change", (event: Event) => {
         const target = event.target as HTMLInputElement;
         void AgentSheet.onOverrideRecoveryDay.call(this, event, target).catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          console.error("Failed to override recovery day for agent", {
+          getDevLogger().error("agent-sheet", "Failed to override recovery day for agent", {
             actorId: this.actor.id,
             actorName: this.actor.name,
             targetValue: target.value,
-            error: err,
-            errorMessage: message,
+            error: err instanceof Error ? err.message : String(err),
           });
           handleActionError(err, "Failed to override recovery day", "INSPECTRES.ErrorUpdateFailed", "Could not update recovery");
         });
@@ -227,13 +224,11 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
         const target = event.currentTarget as unknown as { value?: number };
         const value = Math.max(0, Math.min(6, target.value ?? 0));
         void updateDocument(this.actor, { "system.stress": value }).catch((err: unknown) => {
-          const message = err instanceof Error ? err.message : String(err);
-          console.error("Failed to update stress for agent", {
+          getDevLogger().error("agent-sheet", "Failed to update stress for agent", {
             actorId: this.actor.id,
             actorName: this.actor.name,
             stressValue: value,
-            error: err,
-            errorMessage: message,
+            error: err instanceof Error ? err.message : String(err),
           });
           handleActionError(err, "Failed to update stress", "INSPECTRES.ErrorUpdateFailed", "Could not update stress");
         });
@@ -244,7 +239,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
   static async onSkillRoll(this: AgentSheet, _event: Event, target: HTMLElement): Promise<void> {
     const skillAttr = target.dataset["skill"] ?? null;
     if (!isSkillName(skillAttr)) {
-      console.error("onSkillRoll: missing or invalid data-skill attribute", { skillAttr });
+      getDevLogger().error("agent-sheet", "onSkillRoll: missing or invalid data-skill attribute", { skillAttr });
       return;
     }
     const system = agentSystemData(this.actor);
@@ -294,7 +289,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     if (!this.isEditable) return;
     const skillAttr = target.dataset["skill"] ?? null;
     if (!isSkillName(skillAttr)) {
-      console.error("onSkillStep: missing or invalid data-skill attribute", { skillAttr });
+      getDevLogger().error("agent-sheet", "onSkillStep: missing or invalid data-skill attribute", { skillAttr });
       return;
     }
     const system = agentSystemData(this.actor);
@@ -305,7 +300,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     }
     const skillData = system.skills[skillAttr];
     if (!skillData) {
-      console.error("onSkillStep: skill data missing", { skillAttr, actorId: this.actor.id });
+      getDevLogger().error("agent-sheet", "onSkillStep: skill data missing", { skillAttr, actorId: this.actor.id });
       return;
     }
     const current = skillData.base;
@@ -321,12 +316,12 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     if (!this.isEditable) return;
     const valueStr = target.dataset["value"];
     if (valueStr == null) {
-      console.error("onToggleCool: missing data-value attribute");
+      getDevLogger().error("agent-sheet", "onToggleCool: missing data-value attribute");
       return;
     }
     const pipValue = Number(valueStr);
     if (Number.isNaN(pipValue) || pipValue < 1 || pipValue > 3) {
-      console.error("onToggleCool: invalid data-value", { valueStr });
+      getDevLogger().error("agent-sheet", "onToggleCool: invalid data-value", { valueStr });
       return;
     }
     const system = agentSystemData(this.actor);
@@ -360,12 +355,12 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     if (!this.isEditable) return;
     const idxStr = target.dataset["idx"] ?? null;
     if (idxStr == null) {
-      console.error("onRemoveCharacteristic: missing data-idx attribute");
+      getDevLogger().error("agent-sheet", "onRemoveCharacteristic: missing data-idx attribute");
       return;
     }
     const idx = Number(idxStr);
     if (Number.isNaN(idx) || idx < 0) {
-      console.error("onRemoveCharacteristic: invalid data-idx value", { idxStr });
+      getDevLogger().error("agent-sheet", "onRemoveCharacteristic: invalid data-idx value", { idxStr });
       return;
     }
     const currentSystem = agentSystemData(this.actor);
@@ -587,7 +582,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
     if (!this.isEditable) return;
     const skillAttr = target.dataset["skill"] ?? null;
     if (!isSkillName(skillAttr)) {
-      console.error("onRestoreSkill: missing or invalid data-skill attribute", { skillAttr });
+      getDevLogger().error("agent-sheet", "onRestoreSkill: missing or invalid data-skill attribute", { skillAttr });
       return;
     }
     const system = agentSystemData(this.actor);

--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -5,7 +5,8 @@
 import { getActorSystem } from "../utils/system-cast.js";
 import { updateDocument, createChatMessage } from "../utils/fvtt-boundary.js";
 import { type AgentCharacteristic } from "./agent-schema.js";
-import { executeSkillRoll, executeStressRoll, SKILL_NAMES, type SkillName } from "../rolls/roll-executor.js";
+import { executeSkillRoll, SKILL_NAMES, type SkillName } from "../rolls/roll-executor.js";
+import { buildStressRollDialog } from "./stress-roll-dialog.js";
 import { agentSystemData } from "./agent-system-data.js";
 import { findFranchiseActor, franchiseSystemData } from "../franchise/franchise-utils.js";
 import { handleActionError } from "../utils/ui-errors.js";
@@ -44,59 +45,6 @@ function getRecoveryBannerText(recoveryStatus: ReturnType<typeof computeRecovery
 
 // Store AbortController for each sheet instance to manage checkbox listeners
 const checkboxControllers = new WeakMap<AgentSheet, AbortController>();
-
-
-async function buildStressRollDialog(agent: Actor): Promise<void> {
-  const system = agentSystemData(agent);
-  const maxCool = system.cool;
-
-  const i18n = game.i18n;
-  const stressDiceLabel = i18n?.localize("INSPECTRES.DialogStressDice") ?? "Stress Dice (1–5)";
-  const coolIgnoreLabel = i18n?.format("INSPECTRES.DialogCoolIgnore", { max: String(maxCool) }) ?? `Cool dice to ignore lowest (0–${maxCool})`;
-
-  const result = await foundry.applications.api.DialogV2.wait({
-    window: { title: i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll" },
-    rejectClose: false,
-    render: stopDialogSubmitPropagation,
-    content: `
-      <div class="inspectres-roll-dialog">
-        <label>${stressDiceLabel}: <input type="number" name="stressDice" min="1" max="5" value="1"></label>
-        ${maxCool > 0 ? `<label>${coolIgnoreLabel}: <input type="number" name="coolIgnore" min="0" max="${maxCool}" value="0"></label>` : ""}
-      </div>
-    `,
-    buttons: [
-      {
-        action: "roll",
-        label: i18n?.localize("INSPECTRES.DialogRoll") ?? "Roll",
-        default: true,
-        callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
-          if (!form) {
-            getDevLogger().error("agent-sheet", "buildStressRollDialog: form element not found in dialog");
-            return null;
-          }
-          const data = new FormData(form);
-          const stressDiceCount = Math.max(1, Math.min(5, Number(data.get("stressDice") ?? 1)));
-          const coolDiceUsed = Math.max(0, Math.min(maxCool, Number(data.get("coolIgnore") ?? 0)));
-          return {
-            stressDiceCount: Number.isNaN(stressDiceCount) ? 1 : stressDiceCount,
-            coolDiceUsed: Number.isNaN(coolDiceUsed) ? 0 : coolDiceUsed,
-          };
-        },
-      },
-      {
-        action: "cancel",
-        label: i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel",
-        callback: () => null,
-      },
-    ],
-  });
-
-  if (result === null || result === undefined) return;
-  const params = result as { stressDiceCount: number; coolDiceUsed: number };
-  const franchise = findFranchiseActor();
-  await executeStressRoll(agent, params, franchise);
-}
 
 // HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
 export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {

--- a/foundry/src/agent/restore-skill-sheet.test.ts
+++ b/foundry/src/agent/restore-skill-sheet.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AgentSheet } from "./AgentSheet.js";
 import { MockActorSheetV2 } from "../__mocks__/setup.js";
 import type { AgentData } from "./agent-schema.js";
+import { getDevLogger } from "../utils/dev-logger.js";
 
 // Type assertion: MockActorSheetV2 satisfies AgentSheet interface for testing action handlers.
 // The mock lacks Foundry ApplicationV2 properties unused in these tests, hence the minimal interface.
@@ -63,13 +64,14 @@ describe("AgentSheet.onRestoreSkill - Cool-to-skill recovery button", () => {
 
   it("logs error when skill attribute missing", async () => {
     const sheet = mockSheet as unknown as AgentSheet;
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(getDevLogger(), "error").mockImplementation(() => {});
 
     const target = document.createElement("button");
     // missing data-skill attribute
     await AgentSheet.onRestoreSkill.call(sheet, new Event("click"), target);
 
     expect(errorSpy).toHaveBeenCalledWith(
+      "agent-sheet",
       "onRestoreSkill: missing or invalid data-skill attribute",
       expect.any(Object),
     );

--- a/foundry/src/agent/stress-roll-dialog.ts
+++ b/foundry/src/agent/stress-roll-dialog.ts
@@ -1,0 +1,57 @@
+import { agentSystemData } from "./agent-system-data.js";
+import { executeStressRoll } from "../rolls/roll-executor.js";
+import { findFranchiseActor } from "../franchise/franchise-utils.js";
+import { getDevLogger } from "../utils/dev-logger.js";
+import { stopDialogSubmitPropagation } from "../utils/dialog-utils.js";
+
+export async function buildStressRollDialog(agent: Actor): Promise<void> {
+  const system = agentSystemData(agent);
+  const maxCool = system.cool;
+
+  const i18n = game.i18n;
+  const stressDiceLabel = i18n?.localize("INSPECTRES.DialogStressDice") ?? "Stress Dice (1–5)";
+  const coolIgnoreLabel = i18n?.format("INSPECTRES.DialogCoolIgnore", { max: String(maxCool) }) ?? `Cool dice to ignore lowest (0–${maxCool})`;
+
+  const result = await foundry.applications.api.DialogV2.wait({
+    window: { title: i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll" },
+    rejectClose: false,
+    render: stopDialogSubmitPropagation,
+    content: `
+      <div class="inspectres-roll-dialog">
+        <label>${stressDiceLabel}: <input type="number" name="stressDice" min="1" max="5" value="1"></label>
+        ${maxCool > 0 ? `<label>${coolIgnoreLabel}: <input type="number" name="coolIgnore" min="0" max="${maxCool}" value="0"></label>` : ""}
+      </div>
+    `,
+    buttons: [
+      {
+        action: "roll",
+        label: i18n?.localize("INSPECTRES.DialogRoll") ?? "Roll",
+        default: true,
+        callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
+          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+          if (!form) {
+            getDevLogger().error("agent-sheet", "buildStressRollDialog: form element not found in dialog");
+            return null;
+          }
+          const data = new FormData(form);
+          const stressDiceCount = Math.max(1, Math.min(5, Number(data.get("stressDice") ?? 1)));
+          const coolDiceUsed = Math.max(0, Math.min(maxCool, Number(data.get("coolIgnore") ?? 0)));
+          return {
+            stressDiceCount: Number.isNaN(stressDiceCount) ? 1 : stressDiceCount,
+            coolDiceUsed: Number.isNaN(coolDiceUsed) ? 0 : coolDiceUsed,
+          };
+        },
+      },
+      {
+        action: "cancel",
+        label: i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel",
+        callback: () => null,
+      },
+    ],
+  });
+
+  if (result === null || result === undefined) return;
+  const params = result as { stressDiceCount: number; coolDiceUsed: number };
+  const franchise = findFranchiseActor();
+  await executeStressRoll(agent, params, franchise);
+}

--- a/foundry/src/franchise/franchise-utils.ts
+++ b/foundry/src/franchise/franchise-utils.ts
@@ -6,6 +6,11 @@ export function findFranchiseActor(): Actor | null {
   return game.actors.find((actor) => (actor.type as string) === "franchise") ?? null;
 }
 
+/**
+ * Typed accessor for a franchise actor's system data. Parallel to
+ * `agentSystemData` — callers express the actor's domain at the call site
+ * rather than spelling out the generic at every use.
+ */
 export function franchiseSystemData(actor: RollActor | Actor): FranchiseData {
   return getActorSystem<FranchiseData>(actor);
 }

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -13,6 +13,7 @@ import { registerHandlebarsHelpers } from "./utils/handlebars-helpers.js";
 import { MissionTrackerApp } from "./mission/MissionTrackerApp.js";
 import { onMissionSocketEvent } from "./mission/socket.js";
 import { handleActionError } from "./utils/ui-errors.js";
+import { getDevLogger } from "./utils/dev-logger.js";
 import { autoClearRecoveredAgents } from "./agent/recovery-utils.js";
 import { validateAndFixCoolCap } from "./agent/agent-system-data.js";
 import "./forms/stress-meter.js";
@@ -80,7 +81,7 @@ Hooks.once("init", async function () {
     ]);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error("Failed to load templates:", message);
+    getDevLogger().error("init", "Failed to load templates", { errorMessage: message });
     ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorTemplateLoad") ?? `Template load failed: ${message}`);
   }
 
@@ -138,7 +139,7 @@ Hooks.once("init", async function () {
           rerenderDayDependentSheets("day change");
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
-          console.error("[INSPECTRES] Auto-clear recovered agents failed:", { newDay, error: err, errorMessage: message });
+          getDevLogger().error("init", "Auto-clear recovered agents failed", { newDay, errorMessage: message });
           if (ui.notifications) {
             ui.notifications.error(game.i18n?.localize("INSPECTRES.ErrorAutoRecoverFailed") ?? "Auto-recovery update failed");
           }

--- a/foundry/src/init.ts
+++ b/foundry/src/init.ts
@@ -121,14 +121,14 @@ Hooks.once("init", async function () {
     onChange: (newDay: unknown) => {
       if (typeof newDay !== "number") return;
       if (!Number.isInteger(newDay) || newDay < 1) {
-        console.warn("[INSPECTRES] Invalid currentDay value; ignoring:", { newDay });
+        getDevLogger().warn("init", "Invalid currentDay value; ignoring", { newDay });
         return;
       }
       void (async () => {
         try {
           const result = await autoClearRecoveredAgents(newDay);
           if (result.failed > 0) {
-            console.warn("[INSPECTRES] Some agents failed to auto-clear recovery:", result);
+            getDevLogger().warn("init", "Some agents failed to auto-clear recovery", { result });
             if (ui.notifications) {
               ui.notifications.warn(game.i18n?.localize("INSPECTRES.ErrorPartialRecoveryFailed") ?? "Some agents failed to clear recovery state");
             }
@@ -187,14 +187,14 @@ Hooks.once("ready", function () {
             await actor.update(updates);
           } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
-            console.warn(`[INSPECTRES] Failed to fix Cool cap for ${actor.name}:`, message);
+            getDevLogger().warn("init", "Failed to fix Cool cap", { actor: actor.name, errorMessage: message });
             failedAgents.push(actor.name ?? "Unknown Agent");
           }
         }
       }
       if (failedAgents.length > 0) {
         const names = failedAgents.join(", ");
-        console.warn(`[INSPECTRES] Cool cap enforcement incomplete for: ${names}`);
+        getDevLogger().warn("init", "Cool cap enforcement incomplete", { agents: names });
         ui.notifications?.warn(`Failed to verify Cool cap for: ${names}`);
       }
     })();

--- a/foundry/src/mission/collaboration-mechanics.test.ts
+++ b/foundry/src/mission/collaboration-mechanics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { prepareSkillRollContext } from "../agent/skill-roll-dialog.js";
 import { checkTechnologyRollRequirements } from "../rolls/skill-roll-executor.js";
 import { transitionToConfessionalScene, resetConfessionalScene, type RollScene } from "./confessional-scene.js";
@@ -43,6 +43,15 @@ interface MissionContext {
 }
 
 describe("Collaboration Mechanics E2E", () => {
+  // Scene-token operations require GM permission; tests run in GM context.
+  let savedGame: unknown;
+  beforeEach(() => {
+    savedGame = (globalThis as Record<string, unknown>)["game"];
+  });
+  afterEach(() => {
+    (globalThis as Record<string, unknown>)["game"] = savedGame;
+  });
+
   describe("Private Life + Requirements + Confessional", () => {
     it("gates augmentations for private-life roll", () => {
       const context: MissionContext = {
@@ -84,6 +93,7 @@ describe("Collaboration Mechanics E2E", () => {
     });
 
     it("transitions agents to confessional scene", async () => {
+      (globalThis as Record<string, unknown>)["game"] = { user: { isGM: true } };
       // Create test token to track scene updates
       const testToken = new TestToken("token-1", "scene-original");
 
@@ -105,6 +115,7 @@ describe("Collaboration Mechanics E2E", () => {
       // Mock Foundry global
       const originalScene = makeFakeScene("scene-original", "Original");
       (globalThis as Record<string, unknown>)["game"] = {
+        user: { isGM: true },
         scenes: { get: (id: string) => (id === "scene-original" ? originalScene : null) },
       };
 
@@ -126,6 +137,7 @@ describe("Collaboration Mechanics E2E", () => {
       // Mock Foundry global for confessional reset
       const originalSceneForComplex = makeFakeScene("scene-original", "Original");
       (globalThis as Record<string, unknown>)["game"] = {
+        user: { isGM: true },
         scenes: { get: (id: string) => (id === "scene-original" ? originalSceneForComplex : null) },
       };
 

--- a/foundry/src/mission/collaboration-mechanics.test.ts
+++ b/foundry/src/mission/collaboration-mechanics.test.ts
@@ -6,21 +6,32 @@ import type { SkillName } from "../rolls/roll-executor.js";
 
 // Test fixtures matching RollScene interface
 class TestToken {
-  sceneId: string;
-  x: number;
-  y: number;
+  readonly id: string;
+  readonly parent: { readonly id: string };
+  deleted: boolean;
 
   constructor(id: string, sceneId: string = "scene-original") {
-    this.sceneId = sceneId;
-    this.x = 0;
-    this.y = 0;
+    this.id = id;
+    this.parent = { id: sceneId };
+    this.deleted = false;
   }
 
-  async update(data: { sceneId?: string; x?: number; y?: number }): Promise<void> {
-    if (data.sceneId !== undefined) this.sceneId = data.sceneId;
-    if (data.x !== undefined) this.x = data.x;
-    if (data.y !== undefined) this.y = data.y;
+  toObject(): Record<string, unknown> {
+    return { _id: this.id };
   }
+
+  async delete(): Promise<void> {
+    this.deleted = true;
+  }
+}
+
+function makeFakeScene(id: string, name: string): RollScene {
+  return {
+    id,
+    name,
+    activate: async () => ({}) as Scene,
+    createEmbeddedDocuments: async (_type: string, _data: Record<string, unknown>[]) => [],
+  };
 }
 
 interface MissionContext {
@@ -76,11 +87,7 @@ describe("Collaboration Mechanics E2E", () => {
       // Create test token to track scene updates
       const testToken = new TestToken("token-1", "scene-original");
 
-      const mockScene: RollScene = {
-        id: "scene-confessional",
-        name: "Confessional",
-        activate: async () => ({} as Scene),
-      };
+      const mockScene = makeFakeScene("scene-confessional", "Confessional");
 
       const mockAgent = {
         id: "agent-1",
@@ -96,8 +103,9 @@ describe("Collaboration Mechanics E2E", () => {
 
     it("returns agent from confessional after use", async () => {
       // Mock Foundry global
+      const originalScene = makeFakeScene("scene-original", "Original");
       (globalThis as Record<string, unknown>)["game"] = {
-        scenes: { get: (id: string) => (id === "scene-original" ? {} : null) },
+        scenes: { get: (id: string) => (id === "scene-original" ? originalScene : null) },
       };
 
       const testToken = new TestToken("token-1", "scene-original");
@@ -116,8 +124,9 @@ describe("Collaboration Mechanics E2E", () => {
 
     it("handles complex mission with all three mechanics", async () => {
       // Mock Foundry global for confessional reset
+      const originalSceneForComplex = makeFakeScene("scene-original", "Original");
       (globalThis as Record<string, unknown>)["game"] = {
-        scenes: { get: (id: string) => (id === "scene-original" ? {} : null) },
+        scenes: { get: (id: string) => (id === "scene-original" ? originalSceneForComplex : null) },
       };
 
       const context: MissionContext = {
@@ -149,11 +158,7 @@ describe("Collaboration Mechanics E2E", () => {
       // Step 3: Transition to confessional
       const testToken = new TestToken("token-1", "scene-original");
 
-      const mockScene: RollScene = {
-        id: "scene-confessional",
-        name: "Confessional",
-        activate: async () => ({} as Scene),
-      };
+      const mockScene = makeFakeScene("scene-confessional", "Confessional");
       const mockAgent = {
         id: "agent-1",
         name: context.agentName,

--- a/foundry/src/mission/confessional-scene.test.ts
+++ b/foundry/src/mission/confessional-scene.test.ts
@@ -1,34 +1,41 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { transitionToConfessionalScene, resetConfessionalScene, type RollScene, type RollActor } from "./confessional-scene.js";
+import { transitionToConfessionalScene, resetConfessionalScene, type RollScene, type RollActor, type RollToken } from "./confessional-scene.js";
 
-// Test fixtures matching RollScene interface
-function makeTestScene(id: string = "scene-confessional"): RollScene {
-  const scene: RollScene = {
-    id,
-    name: "Confessional",
-    activate: async () => {
-      return {} as Scene;
-    },
-  };
-  return scene;
+interface CreatedTokenSpec {
+  sceneId: string;
+  data: Record<string, unknown>;
 }
 
-// Test fixtures matching RollActor interface
-class TestToken {
+interface FakeScene {
+  readonly id: string;
+  readonly name: string;
+  activate: () => Promise<Scene>;
+  createEmbeddedDocuments: (type: string, data: Record<string, unknown>[]) => Promise<unknown>;
+}
+
+class TestToken implements RollToken {
+  readonly id: string;
   sceneId: string;
   x: number;
   y: number;
+  deleted: boolean;
+  readonly parent: { readonly id: string };
 
   constructor(id: string, sceneId: string = "scene-original") {
+    this.id = id;
     this.sceneId = sceneId;
     this.x = 0;
     this.y = 0;
+    this.deleted = false;
+    this.parent = { id: sceneId };
   }
 
-  async update(data: { sceneId?: string; x?: number; y?: number }): Promise<void> {
-    if (data.sceneId !== undefined) this.sceneId = data.sceneId;
-    if (data.x !== undefined) this.x = data.x;
-    if (data.y !== undefined) this.y = data.y;
+  toObject(): Record<string, unknown> {
+    return { _id: this.id, x: this.x, y: this.y };
+  }
+
+  async delete(): Promise<void> {
+    this.deleted = true;
   }
 }
 
@@ -40,12 +47,36 @@ function makeTestActor(id: string, name: string, tokens: TestToken[] = []): Roll
   };
 }
 
+function makeFakeScene(id: string, name: string, created: CreatedTokenSpec[]): FakeScene {
+  return {
+    id,
+    name,
+    activate: async () => ({}) as Scene,
+    createEmbeddedDocuments: async (type, data) => {
+      if (type !== "Token") throw new Error(`unexpected type ${type}`);
+      for (const d of data) created.push({ sceneId: id, data: d });
+      return [];
+    },
+  };
+}
+
 describe("Confessional Scene Transitions", () => {
+  let created: CreatedTokenSpec[];
+  let originalScene: FakeScene;
+  let confessionalScene: FakeScene;
+
   beforeEach(() => {
-    // Mock Foundry global for resetConfessionalScene
+    created = [];
+    originalScene = makeFakeScene("scene-original", "Original", created);
+    confessionalScene = makeFakeScene("scene-confessional", "Confessional", created);
+
     (globalThis as Record<string, unknown>)["game"] = {
       scenes: {
-        get: (id: string) => (id === "scene-original" ? {} : null),
+        get: (id: string) => {
+          if (id === "scene-original") return originalScene;
+          if (id === "scene-confessional") return confessionalScene;
+          return null;
+        },
       },
     };
   });
@@ -56,53 +87,63 @@ describe("Confessional Scene Transitions", () => {
 
   describe("transitionToConfessionalScene", () => {
     it("activates confessional scene", async () => {
-      const scene = makeTestScene("scene-confessional");
-
-      await transitionToConfessionalScene(scene);
-
-      expect(scene.name).toBe("Confessional");
+      await transitionToConfessionalScene(confessionalScene as unknown as RollScene);
+      expect(confessionalScene.name).toBe("Confessional");
     });
 
-    it("moves agents to confessional scene", async () => {
+    it("creates new tokens on confessional scene and deletes originals", async () => {
       const token1 = new TestToken("token-1", "scene-original");
       const token2 = new TestToken("token-2", "scene-original");
 
       const agent1 = makeTestActor("agent-1", "Agent Sinclair", [token1]);
       const agent2 = makeTestActor("agent-2", "Agent Murphy", [token2]);
 
-      const scene = makeTestScene("scene-confessional");
-
-      const result = await transitionToConfessionalScene(scene, [agent1, agent2]);
+      const result = await transitionToConfessionalScene(
+        confessionalScene as unknown as RollScene,
+        [agent1, agent2],
+      );
 
       expect(result.agentsMoved).toContain("agent-1");
       expect(result.agentsMoved).toContain("agent-2");
-      expect(token1.sceneId).toBe("scene-confessional");
-      expect(token1.x).toBe(400);
-      expect(token1.y).toBe(400);
-      expect(token2.sceneId).toBe("scene-confessional");
+
+      // New tokens created on confessional scene, positioned at 400/400
+      const onConfessional = created.filter((c) => c.sceneId === "scene-confessional");
+      expect(onConfessional).toHaveLength(2);
+      for (const spec of onConfessional) {
+        expect(spec.data["x"]).toBe(400);
+        expect(spec.data["y"]).toBe(400);
+      }
+
+      // Source tokens deleted
+      expect(token1.deleted).toBe(true);
+      expect(token2.deleted).toBe(true);
     });
   });
 
   describe("resetConfessionalScene", () => {
-    it("returns agents to original scene", async () => {
-      const token = new TestToken("token-1", "scene-original");
+    it("returns agents to original scene via create+delete", async () => {
+      const token = new TestToken("token-1", "scene-confessional");
       const agent = makeTestActor("agent-1", "Agent Sinclair", [token]);
 
       const result = await resetConfessionalScene(agent, "scene-original");
 
       expect(result.success).toBe(true);
       expect(result.agentId).toBe("agent-1");
-      expect(token.sceneId).toBe("scene-original");
+
+      const onOriginal = created.filter((c) => c.sceneId === "scene-original");
+      expect(onOriginal).toHaveLength(1);
+      expect(token.deleted).toBe(true);
     });
 
     it("handles missing original scene gracefully", async () => {
-      const token = new TestToken("token-1");
+      const token = new TestToken("token-1", "scene-confessional");
       const agent = makeTestActor("agent-1", "Agent Sinclair", [token]);
 
       const result = await resetConfessionalScene(agent, "nonexistent-scene");
 
       expect(result.success).toBe(false);
       expect(result.agentId).toBe("agent-1");
+      expect(token.deleted).toBe(false);
     });
   });
 });

--- a/foundry/src/mission/confessional-scene.test.ts
+++ b/foundry/src/mission/confessional-scene.test.ts
@@ -71,6 +71,7 @@ describe("Confessional Scene Transitions", () => {
     confessionalScene = makeFakeScene("scene-confessional", "Confessional", created);
 
     (globalThis as Record<string, unknown>)["game"] = {
+      user: { isGM: true },
       scenes: {
         get: (id: string) => {
           if (id === "scene-original") return originalScene;

--- a/foundry/src/mission/confessional-scene.ts
+++ b/foundry/src/mission/confessional-scene.ts
@@ -1,5 +1,3 @@
-import { updateDocument } from "../utils/fvtt-boundary.js";
-
 export interface SceneTransitionResult {
   agentsMoved: string[];
   sceneId: string;
@@ -10,11 +8,14 @@ export interface AgentResetResult {
   agentId: string;
 }
 
-// Structural interface for Foundry Scene (avoids full Foundry type in this module)
+// Structural interface for Foundry Scene (avoids full Foundry type in this module).
+// Includes createEmbeddedDocuments for moving tokens between scenes (#572: TokenDocument.update
+// does not accept sceneId — tokens are scene-embedded and must be re-created on the target).
 export interface RollScene {
   readonly id: string;
   readonly name: string;
   activate(): Promise<Scene>;
+  createEmbeddedDocuments(type: string, data: Record<string, unknown>[]): Promise<unknown>;
 }
 
 // Structural interface for Foundry Actor (avoids full Foundry type in this module)
@@ -24,21 +25,46 @@ export interface RollActor {
   getActiveTokens(linked?: boolean): TokenDocument[];
 }
 
+// Structural interface for the subset of TokenDocument used during scene transition.
+// Real TokenDocument exposes parent (the Scene), toObject() (snapshot for re-create), and delete().
+export interface RollToken {
+  readonly parent: { readonly id: string } | null;
+  toObject(): Record<string, unknown>;
+  delete(): Promise<unknown>;
+}
+
+interface SceneRegistry {
+  scenes?: { get(id: string): RollScene | null };
+}
+
+function getScene(id: string): RollScene | null {
+  const registry = globalThis as unknown as { game?: SceneRegistry };
+  return registry.game?.scenes?.get(id) ?? null;
+}
+
+async function moveToken(token: TokenDocument, targetScene: RollScene, x?: number, y?: number): Promise<void> {
+  const t = token as unknown as RollToken;
+  const base = t.toObject();
+  const data: Record<string, unknown> = { ...base };
+  if (x !== undefined) data["x"] = x;
+  if (y !== undefined) data["y"] = y;
+  await targetScene.createEmbeddedDocuments("Token", [data]);
+  await t.delete();
+}
+
 export async function transitionToConfessionalScene(
   scene: RollScene,
   agents?: RollActor[],
 ): Promise<SceneTransitionResult> {
-  // Activate the confessional scene
   await scene.activate();
 
   const agentsMoved: string[] = [];
 
-  // Move each agent's token to confessional scene
   if (agents) {
     for (const agent of agents) {
       const tokens = agent.getActiveTokens(true);
       for (const token of tokens) {
-        await updateDocument(token, { sceneId: scene.id, x: 400, y: 400 });
+        await moveToken(token, scene, 400, 400);
         agentsMoved.push(agent.id);
       }
     }
@@ -54,8 +80,7 @@ export async function resetConfessionalScene(
   agent: RollActor,
   originalSceneId: string,
 ): Promise<AgentResetResult> {
-  // Validate original scene exists
-  const originalScene = game.scenes?.get(originalSceneId);
+  const originalScene = getScene(originalSceneId);
   if (!originalScene) {
     return {
       success: false,
@@ -63,10 +88,9 @@ export async function resetConfessionalScene(
     };
   }
 
-  // Move agent tokens back to original scene
   const tokens = agent.getActiveTokens(true);
   for (const token of tokens) {
-    await updateDocument(token, { sceneId: originalSceneId });
+    await moveToken(token, originalScene);
   }
 
   return {

--- a/foundry/src/mission/confessional-scene.ts
+++ b/foundry/src/mission/confessional-scene.ts
@@ -35,11 +35,22 @@ export interface RollToken {
 
 interface SceneRegistry {
   scenes?: { get(id: string): RollScene | null };
+  user?: { isGM: boolean };
 }
 
 function getScene(id: string): RollScene | null {
   const registry = globalThis as unknown as { game?: SceneRegistry };
   return registry.game?.scenes?.get(id) ?? null;
+}
+
+// Token moves require GM permission in Foundry. Asserting at the boundary
+// surfaces a clear error instead of letting Foundry's create/delete reject silently.
+function assertGm(operation: string): void {
+  const registry = globalThis as unknown as { game?: SceneRegistry };
+  const isGm = registry.game?.user?.isGM ?? true; // tests run without game.user; default-allow there
+  if (!isGm) {
+    throw new Error(`${operation} requires GM permission`);
+  }
 }
 
 async function moveToken(token: TokenDocument, targetScene: RollScene, x?: number, y?: number): Promise<void> {
@@ -56,6 +67,7 @@ export async function transitionToConfessionalScene(
   scene: RollScene,
   agents?: RollActor[],
 ): Promise<SceneTransitionResult> {
+  assertGm("transitionToConfessionalScene");
   await scene.activate();
 
   const agentsMoved: string[] = [];
@@ -80,6 +92,7 @@ export async function resetConfessionalScene(
   agent: RollActor,
   originalSceneId: string,
 ): Promise<AgentResetResult> {
+  assertGm("resetConfessionalScene");
   const originalScene = getScene(originalSceneId);
   if (!originalScene) {
     return {

--- a/foundry/src/rolls/bank-roll.ts
+++ b/foundry/src/rolls/bank-roll.ts
@@ -1,0 +1,59 @@
+import { BANK_ROLL_CHART } from "./roll-charts.js";
+import { type BankDieResolution, type BankResolutionSummary } from "./roll-types.js";
+import { type FranchiseData } from "../franchise/franchise-schema.js";
+import { getActorSystem, type RollActor } from "../utils/system-cast.js";
+import { getDevLogger } from "../utils/dev-logger.js";
+import { isDieFace, actorUpdate, rollDice, postChatCard } from "./roll-helpers.js";
+
+/** Pure function: evaluates bank die results against BANK_ROLL_CHART. */
+export function resolveBankDice(faces: number[], currentBank: number): BankResolutionSummary {
+  const resolutions: BankDieResolution[] = [];
+  let delta = 0;
+  let lostAll = false;
+
+  for (const face of faces) {
+    if (!isDieFace(face)) {
+      getDevLogger().error("bank-roll", `resolveBankDice: invalid die face ${face}, skipping`);
+      continue;
+    }
+    const entry = BANK_ROLL_CHART[face];
+    const loseAllBank = "loseAllBank" in entry && entry.loseAllBank === true;
+    // net per die: spent 1 to roll it; diceReturned gives back; diceAdded adds more
+    const bankDelta = entry.diceReturned - 1 + entry.diceAdded;
+    resolutions.push({ face, result: entry.result, narration: entry.narration, bankDelta, loseAllBank });
+    if (loseAllBank) {
+      lostAll = true;
+      break;
+    }
+    delta += bankDelta;
+  }
+
+  const finalBankTotal = lostAll ? 0 : Math.max(0, currentBank + delta);
+  return { resolutions, finalBankTotal };
+}
+
+export async function executeBankRoll(franchise: RollActor): Promise<void> {
+  // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
+  const system = getActorSystem<FranchiseData>(franchise);
+  const currentBank = system.bank;
+
+  if (currentBank === 0) {
+    ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnNoBankDice") ?? "No bank dice to roll.");
+    return;
+  }
+
+  const { roll, faces } = await rollDice(currentBank);
+  const summary = resolveBankDice(faces, currentBank);
+
+  await actorUpdate(franchise, { "system.bank": summary.finalBankTotal });
+
+  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
+  const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
+  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
+    rollType: "bank",
+    title: game.i18n?.localize("INSPECTRES.BankRoll") ?? "Bank Roll",
+    resolutions: summary.resolutions,
+    finalBankTotal: summary.finalBankTotal,
+  });
+  await postChatCard(content, speaker, [roll]);
+}

--- a/foundry/src/rolls/client-roll.ts
+++ b/foundry/src/rolls/client-roll.ts
@@ -1,0 +1,51 @@
+import { CLIENT_GENERATION_TABLE } from "./roll-charts.js";
+import { type FranchiseData } from "../franchise/franchise-schema.js";
+import { getActorSystem, type RollActor } from "../utils/system-cast.js";
+import { createChatMessage } from "../utils/fvtt-boundary.js";
+import { getDevLogger } from "../utils/dev-logger.js";
+import { rollDice } from "./roll-helpers.js";
+
+export async function executeClientRoll(franchise: RollActor): Promise<void> {
+  // Client rolls require a franchise actor — cannot be run as a standalone tool.
+  // The franchise provides the GM context for generating random client attributes.
+  // #274: Validate that franchise system is valid before proceeding.
+  try {
+    getActorSystem<FranchiseData>(franchise);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    getDevLogger().error("client-roll", "Client roll validation failed", {
+      franchiseId: franchise.id,
+      franchiseName: franchise.name,
+      errorMessage: message,
+    });
+    ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorClientRollFailed") ?? "Client roll requires valid franchise actor");
+    throw new Error(
+      `Client roll requires valid franchise actor with system data. ${franchise.name} (ID: ${franchise.id}): ${message}`,
+    );
+  }
+
+  const attributes = ["personality", "clientType", "occurrence", "location"] as const;
+  const rolls: Roll[] = [];
+  const generated: Record<string, string> = {};
+
+  for (const attr of attributes) {
+    const { roll, faces } = await rollDice(2);
+    rolls.push(roll);
+    const sum = faces.reduce((acc, f) => acc + f, 0);
+    // 2d6 sums range 2–12; clamp to valid keys
+    const key = Math.max(2, Math.min(12, sum));
+    const table = CLIENT_GENERATION_TABLE[attr] as Record<number, string>;
+    generated[attr] = table[key] ?? "";
+  }
+
+  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
+  const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
+  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
+    rollType: "client",
+    title: game.i18n?.localize("INSPECTRES.ClientRoll") ?? "Client Roll",
+    client: generated,
+  });
+  // Client roll results are GM prep — whisper to all GMs only
+  const gmIds = (game.users?.filter((u) => u.isGM).map((u) => u.id).filter((id): id is string => id !== null)) ?? [];
+  await createChatMessage({ content, speaker, rolls, whisper: gmIds });
+}

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -22,34 +22,14 @@ import { stopDialogSubmitPropagation } from "../utils/dialog-utils.js";
 import { updateDocument, createChatMessage } from "../utils/fvtt-boundary.js";
 import { getDevLogger } from "../utils/dev-logger.js";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export type SkillName = "academics" | "athletics" | "technology" | "contact";
-
-export type RollType = "skill" | "bank" | "stress" | "client";
-type D3Result = 1 | 2 | 3;
-
-type DieFace = 1 | 2 | 3 | 4 | 5 | 6;
-
-export interface BankDieResolution {
-  face: DieFace;
-  result: string;
-  narration: string;
-  bankDelta: number;
-  loseAllBank: boolean;
-}
-
-export interface BankResolutionSummary {
-  resolutions: BankDieResolution[];
-  finalBankTotal: number;
-}
-
-export interface StressRollParams {
-  stressDiceCount: number;
-  coolDiceUsed: number;
-}
+export {
+  type SkillName,
+  type RollType,
+  type BankDieResolution,
+  type BankResolutionSummary,
+  type StressRollParams,
+} from "./roll-types.js";
+import { type SkillName, type BankDieResolution, type BankResolutionSummary, type StressRollParams, type DieFace, type D3Result } from "./roll-types.js";
 
 
 // ---------------------------------------------------------------------------

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -3,7 +3,6 @@ import { getActorSystem, type RollActor } from "../utils/system-cast.js";
 import {
   SKILL_ROLL_CHART,
   STRESS_ROLL_CHART,
-  CLIENT_GENERATION_TABLE,
   DEATH_DISMEMBERMENT_CHART,
   type DeathDismembermentOutcome,
   type SkillRollOutcome,
@@ -710,51 +709,4 @@ export function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): stri
   }
 }
 
-// ---------------------------------------------------------------------------
-// executeClientRoll
-// ---------------------------------------------------------------------------
-
-export async function executeClientRoll(franchise: RollActor): Promise<void> {
-  // Client rolls require a franchise actor — cannot be run as a standalone tool.
-  // The franchise provides the GM context for generating random client attributes.
-  // #274: Validate that franchise system is valid before proceeding.
-  try {
-    getActorSystem<FranchiseData>(franchise);
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    getDevLogger().error("roll-executor", "Client roll validation failed", {
-      franchiseId: franchise.id,
-      franchiseName: franchise.name,
-      errorMessage: message,
-    });
-    ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorClientRollFailed") ?? "Client roll requires valid franchise actor");
-    throw new Error(
-      `Client roll requires valid franchise actor with system data. ${franchise.name} (ID: ${franchise.id}): ${message}`,
-    );
-  }
-
-  const attributes = ["personality", "clientType", "occurrence", "location"] as const;
-  const rolls: Roll[] = [];
-  const generated: Record<string, string> = {};
-
-  for (const attr of attributes) {
-    const { roll, faces } = await rollDice(2);
-    rolls.push(roll);
-    const sum = faces.reduce((acc, f) => acc + f, 0);
-    // 2d6 sums range 2–12; clamp to valid keys
-    const key = Math.max(2, Math.min(12, sum));
-    const table = CLIENT_GENERATION_TABLE[attr] as Record<number, string>;
-    generated[attr] = table[key] ?? "";
-  }
-
-  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
-  const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
-  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
-    rollType: "client",
-    title: game.i18n?.localize("INSPECTRES.ClientRoll") ?? "Client Roll",
-    client: generated,
-  });
-  // Client roll results are GM prep — whisper to all GMs only
-  const gmIds = (game.users?.filter((u) => u.isGM).map((u) => u.id).filter((id): id is string => id !== null)) ?? [];
-  await createChatMessage({ content, speaker, rolls, whisper: gmIds });
-}
+export { executeClientRoll } from "./client-roll.js";

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -3,13 +3,13 @@ import { getActorSystem, type RollActor } from "../utils/system-cast.js";
 import {
   SKILL_ROLL_CHART,
   STRESS_ROLL_CHART,
-  BANK_ROLL_CHART,
   CLIENT_GENERATION_TABLE,
   DEATH_DISMEMBERMENT_CHART,
   type DeathDismembermentOutcome,
   type SkillRollOutcome,
   type StressRollOutcome,
 } from "./roll-charts.js";
+import { resolveBankDice } from "./bank-roll.js";
 import { type AgentData } from "../agent/agent-schema.js";
 import { agentSystemData } from "../agent/agent-system-data.js";
 import { type FranchiseData } from "../franchise/franchise-schema.js";
@@ -36,7 +36,7 @@ export {
   type BankResolutionSummary,
   type StressRollParams,
 } from "./roll-types.js";
-import { type SkillName, type BankDieResolution, type BankResolutionSummary, type StressRollParams, type DieFace, type D3Result } from "./roll-types.js";
+import { type SkillName, type BankResolutionSummary, type StressRollParams, type DieFace, type D3Result } from "./roll-types.js";
 
 
 // ---------------------------------------------------------------------------
@@ -113,36 +113,7 @@ async function getPlayerPenaltyChoice(
 }
 
 
-// ---------------------------------------------------------------------------
-// Pure: resolveBankDice
-// ---------------------------------------------------------------------------
-
-/** Pure function: evaluates bank die results against BANK_ROLL_CHART. */
-export function resolveBankDice(faces: number[], currentBank: number): BankResolutionSummary {
-  const resolutions: BankDieResolution[] = [];
-  let delta = 0;
-  let lostAll = false;
-
-  for (const face of faces) {
-    if (!isDieFace(face)) {
-      getDevLogger().error("roll-executor", `resolveBankDice: invalid die face ${face}, skipping`);
-      continue;
-    }
-    const entry = BANK_ROLL_CHART[face];
-    const loseAllBank = "loseAllBank" in entry && entry.loseAllBank === true;
-    // net per die: spent 1 to roll it; diceReturned gives back; diceAdded adds more
-    const bankDelta = entry.diceReturned - 1 + entry.diceAdded;
-    resolutions.push({ face, result: entry.result, narration: entry.narration, bankDelta, loseAllBank });
-    if (loseAllBank) {
-      lostAll = true;
-      break;
-    }
-    delta += bankDelta;
-  }
-
-  const finalBankTotal = lostAll ? 0 : Math.max(0, currentBank + delta);
-  return { resolutions, finalBankTotal };
-}
+export { resolveBankDice, executeBankRoll } from "./bank-roll.js";
 
 // ---------------------------------------------------------------------------
 // Card type mapping
@@ -556,36 +527,6 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
   });
   if (result === null || result === undefined) return null;
   return result as SkillRollAugmentation;
-}
-
-// ---------------------------------------------------------------------------
-// executeBankRoll
-// ---------------------------------------------------------------------------
-
-export async function executeBankRoll(franchise: RollActor): Promise<void> {
-  // fvtt-types v13 + template.json: requires double-cast; see foundry-vite.md
-  const system = getActorSystem<FranchiseData>(franchise);
-  const currentBank = system.bank;
-
-  if (currentBank === 0) {
-    ui.notifications?.warn(game.i18n?.localize("INSPECTRES.WarnNoBankDice") ?? "No bank dice to roll.");
-    return;
-  }
-
-  const { roll, faces } = await rollDice(currentBank);
-  const summary = resolveBankDice(faces, currentBank);
-
-  await actorUpdate(franchise, { "system.bank": summary.finalBankTotal });
-
-  // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
-  const speaker = ChatMessage.getSpeaker({ actor: franchise as Actor });
-  const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
-    rollType: "bank",
-    title: game.i18n?.localize("INSPECTRES.BankRoll") ?? "Bank Roll",
-    resolutions: summary.resolutions,
-    finalBankTotal: summary.finalBankTotal,
-  });
-  await postChatCard(content, speaker, [roll]);
 }
 
 // ---------------------------------------------------------------------------

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -20,6 +20,7 @@ import { prepareSkillRollContext, type SkillRollContextInput } from "../agent/sk
 import { checkTechnologyRollRequirements } from "./skill-roll-executor.js";
 import { stopDialogSubmitPropagation } from "../utils/dialog-utils.js";
 import { updateDocument, createChatMessage } from "../utils/fvtt-boundary.js";
+import { getDevLogger } from "../utils/dev-logger.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -172,7 +173,7 @@ export function resolveBankDice(faces: number[], currentBank: number): BankResol
 
   for (const face of faces) {
     if (!isDieFace(face)) {
-      console.error(`resolveBankDice: invalid die face ${face}, skipping`);
+      getDevLogger().error("roll-executor", `resolveBankDice: invalid die face ${face}, skipping`);
       continue;
     }
     const entry = BANK_ROLL_CHART[face];
@@ -564,7 +565,7 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
         callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
           const form = dialog.element.querySelector("form") as HTMLFormElement | null;
           if (!form) {
-            console.error("buildSkillRollDialog: form element not found in dialog");
+            getDevLogger().error("roll-executor", "buildSkillRollDialog: form element not found in dialog");
             return null;
           }
           const data = new FormData(form);
@@ -579,7 +580,8 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
             ? requirementTierRaw
             : undefined;
           if (requirementTierRaw && !requirementTier) {
-            console.error(
+            getDevLogger().error(
+              "roll-executor",
               `buildSkillRollDialog: invalid requirementTier value "${requirementTierRaw}". Expected one of: common, rare, exotic. Treating as undefined.`,
             );
           }
@@ -827,10 +829,9 @@ export async function executeClientRoll(franchise: RollActor): Promise<void> {
     getActorSystem<FranchiseData>(franchise);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error("[INSPECTRES] Client roll validation failed:", {
+    getDevLogger().error("roll-executor", "Client roll validation failed", {
       franchiseId: franchise.id,
       franchiseName: franchise.name,
-      error: err,
       errorMessage: message,
     });
     ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorClientRollFailed") ?? "Client roll requires valid franchise actor");

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -19,8 +19,15 @@ import { type ItemRarity, isRollSufficient, checkDefect } from "../mission/requi
 import { prepareSkillRollContext, type SkillRollContextInput } from "../agent/skill-roll-dialog.js";
 import { checkTechnologyRollRequirements } from "./skill-roll-executor.js";
 import { stopDialogSubmitPropagation } from "../utils/dialog-utils.js";
-import { updateDocument, createChatMessage } from "../utils/fvtt-boundary.js";
+import { createChatMessage } from "../utils/fvtt-boundary.js";
 import { getDevLogger } from "../utils/dev-logger.js";
+import {
+  isDieFace,
+  actorUpdate,
+  rollDice,
+  getOutcomeClassification,
+  postChatCard,
+} from "./roll-helpers.js";
 
 export {
   type SkillName,
@@ -33,16 +40,8 @@ import { type SkillName, type BankDieResolution, type BankResolutionSummary, typ
 
 
 // ---------------------------------------------------------------------------
-// Guards and helpers
+// Skill-specific helper
 // ---------------------------------------------------------------------------
-
-function isDieFace(n: number): n is DieFace {
-  return n >= 1 && n <= 6;
-}
-
-function extractFaces(roll: Roll): number[] {
-  return roll.dice.flatMap((t) => t.results).filter((r) => r.active !== false).map((r) => r.result);
-}
 
 function applySkillPenalty(
   updateData: Record<string, unknown>,
@@ -52,33 +51,6 @@ function applySkillPenalty(
 ): void {
   const currentPenalty = system.skills[targetSkill]?.penalty ?? 0;
   updateData[`system.skills.${targetSkill}.penalty`] = currentPenalty + penaltyAmount;
-}
-
-async function actorUpdate(actor: RollActor, data: Record<string, unknown>): Promise<void> {
-  await updateDocument(actor, data);
-}
-
-async function rollDice(count: number): Promise<{ roll: Roll; faces: number[] }> {
-  const roll = new Roll(`${count}d6`);
-  await roll.evaluate();
-  return { roll, faces: extractFaces(roll) };
-}
-
-function getOutcomeClassification(highestFace: number): "good" | "partial" | "bad" {
-  if (highestFace < 1 || highestFace > 6) {
-    throw new Error(`getOutcomeClassification: die face must be 1-6, got ${highestFace}`);
-  }
-  if (highestFace >= 5) return "good";
-  if (highestFace >= 3) return "partial";
-  return "bad";
-}
-
-async function postChatCard(
-  content: string,
-  speaker: ReturnType<typeof ChatMessage.getSpeaker>,
-  rolls: Roll[],
-): Promise<void> {
-  await createChatMessage({ content, speaker, rolls });
 }
 
 // All valid skills for penalty selection — drives dialog rendering and validation.

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -2,18 +2,13 @@ export { type RollActor } from "../utils/system-cast.js";
 import { getActorSystem, type RollActor } from "../utils/system-cast.js";
 import {
   SKILL_ROLL_CHART,
-  STRESS_ROLL_CHART,
-  DEATH_DISMEMBERMENT_CHART,
-  type DeathDismembermentOutcome,
   type SkillRollOutcome,
-  type StressRollOutcome,
 } from "./roll-charts.js";
 import { resolveBankDice } from "./bank-roll.js";
 import { type AgentData } from "../agent/agent-schema.js";
 import { agentSystemData } from "../agent/agent-system-data.js";
 import { type FranchiseData } from "../franchise/franchise-schema.js";
 import { emitMissionPoolUpdated } from "../mission/socket.js";
-import { getCurrentDay } from "../agent/recovery-utils.js";
 import { type ItemRarity, isRollSufficient, checkDefect } from "../mission/requirements-checker.js";
 import { prepareSkillRollContext, type SkillRollContextInput } from "../agent/skill-roll-dialog.js";
 import { checkTechnologyRollRequirements } from "./skill-roll-executor.js";
@@ -25,7 +20,6 @@ import {
   actorUpdate,
   rollDice,
   getOutcomeClassification,
-  postChatCard,
 } from "./roll-helpers.js";
 
 export {
@@ -35,84 +29,11 @@ export {
   type BankResolutionSummary,
   type StressRollParams,
 } from "./roll-types.js";
-import { type SkillName, type BankResolutionSummary, type StressRollParams, type DieFace, type D3Result } from "./roll-types.js";
-
-
-// ---------------------------------------------------------------------------
-// Skill-specific helper
-// ---------------------------------------------------------------------------
-
-function applySkillPenalty(
-  updateData: Record<string, unknown>,
-  system: AgentData,
-  penaltyAmount: number,
-  targetSkill: SkillName,
-): void {
-  const currentPenalty = system.skills[targetSkill]?.penalty ?? 0;
-  updateData[`system.skills.${targetSkill}.penalty`] = currentPenalty + penaltyAmount;
-}
-
-// All valid skills for penalty selection — drives dialog rendering and validation.
-// Used to: (1) enumerate dialog options, (2) validate form input against known set.
-// If SkillName ever changes, this constant fails to compile until updated.
-export const SKILL_NAMES = ["academics", "athletics", "technology", "contact"] as const satisfies readonly SkillName[];
-
-async function getPlayerPenaltyChoice(
-  system: AgentData,
-  penaltyAmount: number,
-): Promise<SkillName | null> {
-  const skills: Array<{ name: SkillName; rank: number }> = SKILL_NAMES.map((name) => ({
-    name,
-    rank: system.skills[name]?.base ?? 0,
-  }));
-
-  const content = `
-    <div class="inspectres-penalty-dialog">
-      <p><strong>${game.i18n?.localize("INSPECTRES.PenaltyDialogPrompt") ?? "Choose a skill to penalize"}</strong></p>
-      <p>${game.i18n?.format("INSPECTRES.PenaltyDialogAmount", { amount: String(penaltyAmount) }) ?? `Penalty: -${penaltyAmount} die`}</p>
-      ${skills.map((skill, idx) => `
-        <label><input type="radio" name="selectedSkill" value="${skill.name}"${idx === 0 ? " checked" : ""}> ${game.i18n?.localize(`INSPECTRES.Skill.${skill.name}`) ?? skill.name} (${skill.rank})</label>
-      `).join("")}
-    </div>
-  `;
-
-  const result = await foundry.applications.api.DialogV2.wait({
-    window: { title: game.i18n?.localize("INSPECTRES.PenaltyDialogTitle") ?? "Stress Penalty" },
-    classes: ["inspectres"],
-    rejectClose: false,
-    render: stopDialogSubmitPropagation,
-    content,
-    buttons: [
-      {
-        action: "select",
-        label: game.i18n?.localize("INSPECTRES.DialogOK") ?? "OK",
-        default: true,
-        callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
-          if (!form) return null;
-          const data = new FormData(form);
-          const selectedSkill = data.get("selectedSkill");
-          if (!selectedSkill || typeof selectedSkill !== "string") return null;
-          // Validate selected skill is one of the known valid options.
-          // Prevents malformed form or DOM manipulation from writing to arbitrary skill paths.
-          if (!SKILL_NAMES.includes(selectedSkill as SkillName)) return null;
-          return selectedSkill as SkillName;
-        },
-      },
-      {
-        action: "cancel",
-        label: game.i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel",
-        callback: () => null,
-      },
-    ],
-  });
-
-  if (result === null || result === undefined) return null;
-  return result as SkillName;
-}
+import { type SkillName, type BankResolutionSummary, type DieFace } from "./roll-types.js";
 
 
 export { resolveBankDice, executeBankRoll } from "./bank-roll.js";
+export { executeStressRoll, buildPenaltyNote, SKILL_NAMES } from "./stress-roll.js";
 
 // ---------------------------------------------------------------------------
 // Card type mapping
@@ -528,185 +449,5 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
   return result as SkillRollAugmentation;
 }
 
-// ---------------------------------------------------------------------------
-// Stress Roll Helpers (reduce executeStressRoll complexity)
-// ---------------------------------------------------------------------------
-
-/** Compute effective face after cool dice removed. */
-function getStressOutcomeFace(faces: number[], coolDiceUsed: number): DieFace {
-  const sorted = [...faces].sort((a, b) => a - b);
-  const active = sorted.slice(coolDiceUsed);
-  const rawLowest = active.length > 0 ? (active[0] ?? 6) : 6;
-  return isDieFace(rawLowest) ? rawLowest : 1;
-}
-
-/** Roll for death outcome if death mode and outcome is fatal. */
-async function rollDeathOutcome(
-  agent: RollActor,
-  deathModeActive: boolean,
-  effectiveFace: DieFace,
-): Promise<DeathDismembermentOutcome | null> {
-  if (!deathModeActive || effectiveFace > 2) return null;
-
-  const roll = await new Roll("1d3").evaluate();
-  const result = roll.total ?? 0;
-  if (result < 1 || result > 3) {
-    const errorMsg = `Invalid d3 result in death roll: ${result} (expected 1–3). Stress roll aborted. Agent: ${agent.name} (${agent.id})`;
-    ui.notifications?.error("[INSPECTRES] Death roll validation failed");
-    throw new Error(errorMsg);
-  }
-  const deathKey = result as D3Result;
-  const outcome = DEATH_DISMEMBERMENT_CHART[deathKey];
-  if (!outcome) {
-    const errorMsg = `Death outcome missing for d3 result ${deathKey}. This indicates corrupted DEATH_DISMEMBERMENT_CHART. Agent: ${agent.name} (${agent.id})`;
-    ui.notifications?.error("[INSPECTRES] Death chart lookup failed");
-    throw new Error(errorMsg);
-  }
-  return outcome;
-}
-
-/** Get penalty choices from player (before applying updates). */
-async function getPenaltyChoices(
-  system: AgentData,
-  effectiveFace: DieFace,
-  outcome: StressRollOutcome,
-  stressDiceCount: number,
-): Promise<{ meltdownSkill: SkillName | null; penaltySkill: SkillName | null }> {
-  let meltdownSkill: SkillName | null = null;
-  let penaltySkill: SkillName | null = null;
-
-  if (effectiveFace === 1) {
-    meltdownSkill = await getPlayerPenaltyChoice(system, stressDiceCount);
-  } else if (outcome.skillPenalty > 0) {
-    penaltySkill = await getPlayerPenaltyChoice(system, outcome.skillPenalty);
-  }
-
-  return { meltdownSkill, penaltySkill };
-}
-
-/** Build update data from stress roll outcome and choices. */
-function buildStressUpdateData(
-  system: AgentData,
-  effectiveFace: DieFace,
-  outcome: StressRollOutcome,
-  meltdownSkill: SkillName | null,
-  penaltySkill: SkillName | null,
-  deathOutcome: DeathDismembermentOutcome | null,
-  stressDiceCount: number,
-): Record<string, unknown> {
-  const updateData: Record<string, unknown> = {};
-
-  if (effectiveFace === 1) {
-    updateData["system.cool"] = 0;
-    if (meltdownSkill) {
-      applySkillPenalty(updateData, system, stressDiceCount, meltdownSkill);
-    }
-  } else {
-    if (outcome.coolGain > 0) {
-      updateData["system.cool"] = system.cool + outcome.coolGain;
-    }
-    if (penaltySkill) {
-      applySkillPenalty(updateData, system, outcome.skillPenalty, penaltySkill);
-    }
-  }
-
-  if (deathOutcome) {
-    if ("isDead" in deathOutcome && deathOutcome.isDead) {
-      updateData["system.isDead"] = true;
-    } else if ("daysOutOfAction" in deathOutcome) {
-      updateData["system.daysOutOfAction"] = deathOutcome.daysOutOfAction;
-      updateData["system.recoveryStartedAt"] = getCurrentDay();
-    }
-  }
-
-  return updateData;
-}
-
-// ---------------------------------------------------------------------------
-// executeStressRoll
-// ---------------------------------------------------------------------------
-
-export async function executeStressRoll(
-  agent: RollActor,
-  params: StressRollParams,
-  franchise: RollActor | null = null,
-): Promise<void> {
-  if (!game.user?.isGM) {
-    throw new Error("Stress rolls can only be initiated by the GM");
-  }
-
-  // Recovery check is the responsibility of the UI layer (AgentSheet).
-  // The UI displays warnings and prevents roll initiation for agents who are recovering/dead.
-  // Removing this defensive check prevents error translation loss and focuses validation at the boundary.
-  // If an agent somehow rolls while recovering due to a UI race condition, the error should propagate to the caller.
-
-  const system = agentSystemData(agent);
-  const { stressDiceCount, coolDiceUsed } = params;
-
-  const { roll, faces } = await rollDice(stressDiceCount);
-  const effectiveFace = getStressOutcomeFace(faces, coolDiceUsed);
-  const outcome = STRESS_ROLL_CHART[effectiveFace];
-
-  const franchiseSystem = franchise ? getActorSystem<FranchiseData>(franchise) : null;
-  const deathModeActive = franchiseSystem?.deathMode ?? false;
-  const deathOutcome = await rollDeathOutcome(agent, deathModeActive, effectiveFace);
-
-  // Issue #440: Validate all player inputs (penalty dialogs) BEFORE applying any state changes.
-  const { meltdownSkill, penaltySkill } = await getPenaltyChoices(system, effectiveFace, outcome, stressDiceCount);
-
-  // Build update data from choices
-  const updateData = buildStressUpdateData(system, effectiveFace, outcome, meltdownSkill, penaltySkill, deathOutcome, stressDiceCount);
-
-  if (Object.keys(updateData).length > 0) {
-    try {
-      await actorUpdate(agent, updateData);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      const failedFields = Object.keys(updateData).join(", ");
-      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorStressRollFailed") ?? "Failed to apply stress roll to agent");
-      const userError = new Error(
-        `Failed to apply stress roll to ${agent.name}: ${message}. Failed fields: ${failedFields}`,
-      );
-      throw userError;
-    }
-  }
-
-  // Hazard pay (rules: +1 franchise die per non-Weird agent at mission end) is deferred to mission resolution.
-  // See GitHub issue for implementation of mission-end hazard pay calculation.
-
-  // Only post ChatMessage if franchise is not in debt mode (#455)
-  if (!franchiseSystem?.debtMode) {
-    // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
-    const speaker = ChatMessage.getSpeaker({ actor: agent as Actor });
-    const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
-      rollType: "stress",
-      title: game.i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll",
-      result: deathOutcome?.result ?? outcome.result,
-      narration: deathOutcome?.narration ?? outcome.narration,
-      stressDiceCount,
-      coolDiceUsed,
-      diceRolled: faces,
-      effectiveFace,
-      deathOutcome: deathOutcome ?? null,
-      penaltyNote: !deathOutcome && effectiveFace <= 3 ? buildPenaltyNote(effectiveFace as 1 | 2 | 3, stressDiceCount) : null,
-    });
-    await postChatCard(content, speaker, [roll]);
-  }
-}
-
-export function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): string {
-  switch (face) {
-    case 3:
-      return game.i18n?.localize("INSPECTRES.PenaltyNote.Minor") ?? "Minor consequence";
-    case 2:
-      return game.i18n?.localize("INSPECTRES.PenaltyNote.Major") ?? "Major consequence";
-    case 1:
-      return game.i18n?.format("INSPECTRES.PenaltyNote.Meltdown", { count: String(stressDiceCount) }) ?? `Meltdown (${stressDiceCount} stress dice)`;
-    default: {
-      const _exhaustive: never = face;
-      throw new Error(`buildPenaltyNote: unexpected face value ${JSON.stringify(_exhaustive)}`);
-    }
-  }
-}
 
 export { executeClientRoll } from "./client-roll.js";

--- a/foundry/src/rolls/roll-helpers.ts
+++ b/foundry/src/rolls/roll-helpers.ts
@@ -1,0 +1,38 @@
+import { type DieFace } from "./roll-types.js";
+import { type RollActor } from "../utils/system-cast.js";
+import { updateDocument, createChatMessage } from "../utils/fvtt-boundary.js";
+
+export function isDieFace(n: number): n is DieFace {
+  return n >= 1 && n <= 6;
+}
+
+export function extractFaces(roll: Roll): number[] {
+  return roll.dice.flatMap((t) => t.results).filter((r) => r.active !== false).map((r) => r.result);
+}
+
+export async function actorUpdate(actor: RollActor, data: Record<string, unknown>): Promise<void> {
+  await updateDocument(actor, data);
+}
+
+export async function rollDice(count: number): Promise<{ roll: Roll; faces: number[] }> {
+  const roll = new Roll(`${count}d6`);
+  await roll.evaluate();
+  return { roll, faces: extractFaces(roll) };
+}
+
+export function getOutcomeClassification(highestFace: number): "good" | "partial" | "bad" {
+  if (highestFace < 1 || highestFace > 6) {
+    throw new Error(`getOutcomeClassification: die face must be 1-6, got ${highestFace}`);
+  }
+  if (highestFace >= 5) return "good";
+  if (highestFace >= 3) return "partial";
+  return "bad";
+}
+
+export async function postChatCard(
+  content: string,
+  speaker: ReturnType<typeof ChatMessage.getSpeaker>,
+  rolls: Roll[],
+): Promise<void> {
+  await createChatMessage({ content, speaker, rolls });
+}

--- a/foundry/src/rolls/roll-types.ts
+++ b/foundry/src/rolls/roll-types.ts
@@ -1,0 +1,25 @@
+export type SkillName = "academics" | "athletics" | "technology" | "contact";
+
+export type RollType = "skill" | "bank" | "stress" | "client";
+
+export type D3Result = 1 | 2 | 3;
+
+export type DieFace = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface BankDieResolution {
+  face: DieFace;
+  result: string;
+  narration: string;
+  bankDelta: number;
+  loseAllBank: boolean;
+}
+
+export interface BankResolutionSummary {
+  resolutions: BankDieResolution[];
+  finalBankTotal: number;
+}
+
+export interface StressRollParams {
+  stressDiceCount: number;
+  coolDiceUsed: number;
+}

--- a/foundry/src/rolls/stress-roll.ts
+++ b/foundry/src/rolls/stress-roll.ts
@@ -1,0 +1,245 @@
+import {
+  STRESS_ROLL_CHART,
+  DEATH_DISMEMBERMENT_CHART,
+  type DeathDismembermentOutcome,
+  type StressRollOutcome,
+} from "./roll-charts.js";
+import { type AgentData } from "../agent/agent-schema.js";
+import { agentSystemData } from "../agent/agent-system-data.js";
+import { type FranchiseData } from "../franchise/franchise-schema.js";
+import { getCurrentDay } from "../agent/recovery-utils.js";
+import { stopDialogSubmitPropagation } from "../utils/dialog-utils.js";
+import { getActorSystem, type RollActor } from "../utils/system-cast.js";
+import { isDieFace, actorUpdate, rollDice, postChatCard } from "./roll-helpers.js";
+import { type SkillName, type StressRollParams, type DieFace, type D3Result } from "./roll-types.js";
+
+// All valid skills for penalty selection — drives dialog rendering and validation.
+// If SkillName ever changes, this constant fails to compile until updated.
+export const SKILL_NAMES = ["academics", "athletics", "technology", "contact"] as const satisfies readonly SkillName[];
+
+function applySkillPenalty(
+  updateData: Record<string, unknown>,
+  system: AgentData,
+  penaltyAmount: number,
+  targetSkill: SkillName,
+): void {
+  const currentPenalty = system.skills[targetSkill]?.penalty ?? 0;
+  updateData[`system.skills.${targetSkill}.penalty`] = currentPenalty + penaltyAmount;
+}
+
+async function getPlayerPenaltyChoice(
+  system: AgentData,
+  penaltyAmount: number,
+): Promise<SkillName | null> {
+  const skills: Array<{ name: SkillName; rank: number }> = SKILL_NAMES.map((name) => ({
+    name,
+    rank: system.skills[name]?.base ?? 0,
+  }));
+
+  const content = `
+    <div class="inspectres-penalty-dialog">
+      <p><strong>${game.i18n?.localize("INSPECTRES.PenaltyDialogPrompt") ?? "Choose a skill to penalize"}</strong></p>
+      <p>${game.i18n?.format("INSPECTRES.PenaltyDialogAmount", { amount: String(penaltyAmount) }) ?? `Penalty: -${penaltyAmount} die`}</p>
+      ${skills.map((skill, idx) => `
+        <label><input type="radio" name="selectedSkill" value="${skill.name}"${idx === 0 ? " checked" : ""}> ${game.i18n?.localize(`INSPECTRES.Skill.${skill.name}`) ?? skill.name} (${skill.rank})</label>
+      `).join("")}
+    </div>
+  `;
+
+  const result = await foundry.applications.api.DialogV2.wait({
+    window: { title: game.i18n?.localize("INSPECTRES.PenaltyDialogTitle") ?? "Stress Penalty" },
+    classes: ["inspectres"],
+    rejectClose: false,
+    render: stopDialogSubmitPropagation,
+    content,
+    buttons: [
+      {
+        action: "select",
+        label: game.i18n?.localize("INSPECTRES.DialogOK") ?? "OK",
+        default: true,
+        callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
+          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+          if (!form) return null;
+          const data = new FormData(form);
+          const selectedSkill = data.get("selectedSkill");
+          if (!selectedSkill || typeof selectedSkill !== "string") return null;
+          if (!SKILL_NAMES.includes(selectedSkill as SkillName)) return null;
+          return selectedSkill as SkillName;
+        },
+      },
+      {
+        action: "cancel",
+        label: game.i18n?.localize("INSPECTRES.DialogCancel") ?? "Cancel",
+        callback: () => null,
+      },
+    ],
+  });
+
+  if (result === null || result === undefined) return null;
+  return result as SkillName;
+}
+
+/** Compute effective face after cool dice removed. */
+function getStressOutcomeFace(faces: number[], coolDiceUsed: number): DieFace {
+  const sorted = [...faces].sort((a, b) => a - b);
+  const active = sorted.slice(coolDiceUsed);
+  const rawLowest = active.length > 0 ? (active[0] ?? 6) : 6;
+  return isDieFace(rawLowest) ? rawLowest : 1;
+}
+
+/** Roll for death outcome if death mode and outcome is fatal. */
+async function rollDeathOutcome(
+  agent: RollActor,
+  deathModeActive: boolean,
+  effectiveFace: DieFace,
+): Promise<DeathDismembermentOutcome | null> {
+  if (!deathModeActive || effectiveFace > 2) return null;
+
+  const roll = await new Roll("1d3").evaluate();
+  const result = roll.total ?? 0;
+  if (result < 1 || result > 3) {
+    const errorMsg = `Invalid d3 result in death roll: ${result} (expected 1–3). Stress roll aborted. Agent: ${agent.name} (${agent.id})`;
+    ui.notifications?.error("[INSPECTRES] Death roll validation failed");
+    throw new Error(errorMsg);
+  }
+  const deathKey = result as D3Result;
+  const outcome = DEATH_DISMEMBERMENT_CHART[deathKey];
+  if (!outcome) {
+    const errorMsg = `Death outcome missing for d3 result ${deathKey}. This indicates corrupted DEATH_DISMEMBERMENT_CHART. Agent: ${agent.name} (${agent.id})`;
+    ui.notifications?.error("[INSPECTRES] Death chart lookup failed");
+    throw new Error(errorMsg);
+  }
+  return outcome;
+}
+
+/** Get penalty choices from player (before applying updates). */
+async function getPenaltyChoices(
+  system: AgentData,
+  effectiveFace: DieFace,
+  outcome: StressRollOutcome,
+  stressDiceCount: number,
+): Promise<{ meltdownSkill: SkillName | null; penaltySkill: SkillName | null }> {
+  let meltdownSkill: SkillName | null = null;
+  let penaltySkill: SkillName | null = null;
+
+  if (effectiveFace === 1) {
+    meltdownSkill = await getPlayerPenaltyChoice(system, stressDiceCount);
+  } else if (outcome.skillPenalty > 0) {
+    penaltySkill = await getPlayerPenaltyChoice(system, outcome.skillPenalty);
+  }
+
+  return { meltdownSkill, penaltySkill };
+}
+
+/** Build update data from stress roll outcome and choices. */
+function buildStressUpdateData(
+  system: AgentData,
+  effectiveFace: DieFace,
+  outcome: StressRollOutcome,
+  meltdownSkill: SkillName | null,
+  penaltySkill: SkillName | null,
+  deathOutcome: DeathDismembermentOutcome | null,
+  stressDiceCount: number,
+): Record<string, unknown> {
+  const updateData: Record<string, unknown> = {};
+
+  if (effectiveFace === 1) {
+    updateData["system.cool"] = 0;
+    if (meltdownSkill) {
+      applySkillPenalty(updateData, system, stressDiceCount, meltdownSkill);
+    }
+  } else {
+    if (outcome.coolGain > 0) {
+      updateData["system.cool"] = system.cool + outcome.coolGain;
+    }
+    if (penaltySkill) {
+      applySkillPenalty(updateData, system, outcome.skillPenalty, penaltySkill);
+    }
+  }
+
+  if (deathOutcome) {
+    if ("isDead" in deathOutcome && deathOutcome.isDead) {
+      updateData["system.isDead"] = true;
+    } else if ("daysOutOfAction" in deathOutcome) {
+      updateData["system.daysOutOfAction"] = deathOutcome.daysOutOfAction;
+      updateData["system.recoveryStartedAt"] = getCurrentDay();
+    }
+  }
+
+  return updateData;
+}
+
+export async function executeStressRoll(
+  agent: RollActor,
+  params: StressRollParams,
+  franchise: RollActor | null = null,
+): Promise<void> {
+  if (!game.user?.isGM) {
+    throw new Error("Stress rolls can only be initiated by the GM");
+  }
+
+  // Recovery check is the responsibility of the UI layer (AgentSheet).
+  // If an agent somehow rolls while recovering due to a UI race condition, the error should propagate to the caller.
+
+  const system = agentSystemData(agent);
+  const { stressDiceCount, coolDiceUsed } = params;
+
+  const { roll, faces } = await rollDice(stressDiceCount);
+  const effectiveFace = getStressOutcomeFace(faces, coolDiceUsed);
+  const outcome = STRESS_ROLL_CHART[effectiveFace];
+
+  const franchiseSystem = franchise ? getActorSystem<FranchiseData>(franchise) : null;
+  const deathModeActive = franchiseSystem?.deathMode ?? false;
+  const deathOutcome = await rollDeathOutcome(agent, deathModeActive, effectiveFace);
+
+  // Issue #440: Validate all player inputs (penalty dialogs) BEFORE applying any state changes.
+  const { meltdownSkill, penaltySkill } = await getPenaltyChoices(system, effectiveFace, outcome, stressDiceCount);
+
+  const updateData = buildStressUpdateData(system, effectiveFace, outcome, meltdownSkill, penaltySkill, deathOutcome, stressDiceCount);
+
+  if (Object.keys(updateData).length > 0) {
+    try {
+      await actorUpdate(agent, updateData);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      const failedFields = Object.keys(updateData).join(", ");
+      ui.notifications?.error(game.i18n?.localize("INSPECTRES.ErrorStressRollFailed") ?? "Failed to apply stress roll to agent");
+      throw new Error(
+        `Failed to apply stress roll to ${agent.name}: ${message}. Failed fields: ${failedFields}`,
+      );
+    }
+  }
+
+  if (!franchiseSystem?.debtMode) {
+    // ChatMessage.getSpeaker requires the full Actor type; RollActor satisfies the needed fields at runtime
+    const speaker = ChatMessage.getSpeaker({ actor: agent as Actor });
+    const content = await foundry.applications.handlebars.renderTemplate("systems/inspectres/templates/roll-card.hbs", {
+      rollType: "stress",
+      title: game.i18n?.localize("INSPECTRES.StressRoll") ?? "Stress Roll",
+      result: deathOutcome?.result ?? outcome.result,
+      narration: deathOutcome?.narration ?? outcome.narration,
+      stressDiceCount,
+      coolDiceUsed,
+      diceRolled: faces,
+      effectiveFace,
+      deathOutcome: deathOutcome ?? null,
+      penaltyNote: !deathOutcome && effectiveFace <= 3 ? buildPenaltyNote(effectiveFace as 1 | 2 | 3, stressDiceCount) : null,
+    });
+    await postChatCard(content, speaker, [roll]);
+  }
+}
+
+export function buildPenaltyNote(face: 1 | 2 | 3, stressDiceCount: number): string {
+  switch (face) {
+    case 3:
+      return game.i18n?.localize("INSPECTRES.PenaltyNote.Minor") ?? "Minor consequence";
+    case 2:
+      return game.i18n?.localize("INSPECTRES.PenaltyNote.Major") ?? "Major consequence";
+    case 1:
+      return game.i18n?.format("INSPECTRES.PenaltyNote.Meltdown", { count: String(stressDiceCount) }) ?? `Meltdown (${stressDiceCount} stress dice)`;
+    default: {
+      const _exhaustive: never = face;
+      throw new Error(`buildPenaltyNote: unexpected face value ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}

--- a/foundry/src/rolls/stress-roll.ts
+++ b/foundry/src/rolls/stress-roll.ts
@@ -17,6 +17,10 @@ import { type SkillName, type StressRollParams, type DieFace, type D3Result } fr
 // If SkillName ever changes, this constant fails to compile until updated.
 export const SKILL_NAMES = ["academics", "athletics", "technology", "contact"] as const satisfies readonly SkillName[];
 
+function isSkillName(value: string): value is SkillName {
+  return (SKILL_NAMES as readonly string[]).includes(value);
+}
+
 function applySkillPenalty(
   updateData: Record<string, unknown>,
   system: AgentData,
@@ -62,9 +66,9 @@ async function getPlayerPenaltyChoice(
           if (!form) return null;
           const data = new FormData(form);
           const selectedSkill = data.get("selectedSkill");
-          if (!selectedSkill || typeof selectedSkill !== "string") return null;
-          if (!SKILL_NAMES.includes(selectedSkill as SkillName)) return null;
-          return selectedSkill as SkillName;
+          if (typeof selectedSkill !== "string") return null;
+          if (!isSkillName(selectedSkill)) return null;
+          return selectedSkill;
         },
       },
       {

--- a/foundry/vite.config.ts
+++ b/foundry/vite.config.ts
@@ -35,8 +35,7 @@ function walkDirectory(
   try {
     files = fs.readdirSync(dir);
   } catch (err: unknown) {
-    const message = extractErrorMessage(err);
-    throw new Error(`Failed to read directory ${dir}: ${message}`);
+    throw new Error(`Failed to read directory ${dir}: ${extractErrorMessage(err)}`, { cause: err });
   }
   for (const file of files) {
     const filePath = path.join(dir, file);
@@ -44,19 +43,16 @@ function walkDirectory(
     try {
       stat = fs.statSync(filePath);
     } catch (err: unknown) {
-      const message = extractErrorMessage(err);
-      throw new Error(`Failed to stat file ${filePath}: ${message}`);
+      throw new Error(`Failed to stat file ${filePath}: ${extractErrorMessage(err)}`, { cause: err });
     }
     if (stat.isDirectory()) {
       walkDirectory(filePath, callback, options, depth + 1);
     } else if (!filter || filter(file)) {
-      // Filter function tests the file name only (e.g., name.endsWith(".css")).
-      // If no filter provided, all files are processed. Otherwise, only matching files proceed.
+      // Filter tests file name only (e.g., name.endsWith(".css")).
       try {
         callback(filePath);
       } catch (err: unknown) {
-        const message = extractErrorMessage(err);
-        throw new Error(`Failed to process file ${filePath}: ${message}`);
+        throw new Error(`Failed to process file ${filePath}: ${extractErrorMessage(err)}`, { cause: err });
       }
     }
   }
@@ -100,8 +96,7 @@ export default defineConfig({
             source: systemJson,
           });
         } catch (err: unknown) {
-          const message = extractErrorMessage(err);
-          throw new Error(`Failed to read system.json: ${message}`);
+          throw new Error(`Failed to read system.json: ${extractErrorMessage(err)}`, { cause: err });
         }
 
         // Copy template.json (required)
@@ -117,8 +112,7 @@ export default defineConfig({
             source: templateJson,
           });
         } catch (err: unknown) {
-          const message = extractErrorMessage(err);
-          throw new Error(`Failed to read template.json: ${message}`);
+          throw new Error(`Failed to read template.json: ${extractErrorMessage(err)}`, { cause: err });
         }
 
         // Copy styles (including theme subdirectory)
@@ -134,60 +128,46 @@ export default defineConfig({
                   const content = fs.readFileSync(filePath, "utf-8");
                   this.emitFile({ type: "asset", fileName: outPath, source: content });
                 } catch (err: unknown) {
-                  throw new Error(`Failed to read CSS file ${filePath}: ${extractErrorMessage(err)}`);
+                  throw new Error(`Failed to read CSS file ${filePath}: ${extractErrorMessage(err)}`, { cause: err });
                 }
               },
               { filter: (name) => name.endsWith(".css") },
             );
           };
-          try {
-            emitStyleFiles(stylesDir);
-          } catch (err: unknown) {
-            const message = extractErrorMessage(err);
-            throw new Error(`Failed to copy styles: ${message}`);
-          }
+          // walkDirectory already wraps errors with file context; let them propagate.
+          emitStyleFiles(stylesDir);
         }
 
         // Copy lang
         const langDir = path.resolve(__dirname, "src/lang");
         if (fs.existsSync(langDir)) {
-          try {
-            walkDirectory(langDir, (filePath) => {
-              const file = path.basename(filePath);
-              try {
-                const content = fs.readFileSync(filePath, "utf-8");
-                this.emitFile({ type: "asset", fileName: `lang/${file}`, source: content });
-              } catch (err: unknown) {
-                throw new Error(`Failed to read lang file ${filePath}: ${extractErrorMessage(err)}`);
-              }
-            });
-          } catch (err: unknown) {
-            const message = extractErrorMessage(err);
-            throw new Error(`Failed to copy lang: ${message}`);
-          }
+          walkDirectory(langDir, (filePath) => {
+            const file = path.basename(filePath);
+            try {
+              const content = fs.readFileSync(filePath, "utf-8");
+              this.emitFile({ type: "asset", fileName: `lang/${file}`, source: content });
+            } catch (err: unknown) {
+              throw new Error(`Failed to read lang file ${filePath}: ${extractErrorMessage(err)}`, { cause: err });
+            }
+          });
         }
 
         // Copy Handlebars templates
         const templatesDir = path.resolve(__dirname, "src");
         if (fs.existsSync(templatesDir)) {
-          try {
-            walkDirectory(
-              templatesDir,
-              (filePath) => {
-                const fileName = path.basename(filePath);
-                try {
-                  const content = fs.readFileSync(filePath, "utf-8");
-                  this.emitFile({ type: "asset", fileName: `templates/${fileName}`, source: content });
-                } catch (err: unknown) {
-                  throw new Error(`Failed to read template file ${filePath}: ${extractErrorMessage(err)}`);
-                }
-              },
-              { filter: (name) => name.endsWith(".hbs") && name !== "styles" && name !== "lang" },
-            );
-          } catch (err: unknown) {
-            const message = extractErrorMessage(err);
-            throw new Error(`Template build failed: ${message}`);
-          }
+          walkDirectory(
+            templatesDir,
+            (filePath) => {
+              const fileName = path.basename(filePath);
+              try {
+                const content = fs.readFileSync(filePath, "utf-8");
+                this.emitFile({ type: "asset", fileName: `templates/${fileName}`, source: content });
+              } catch (err: unknown) {
+                throw new Error(`Failed to read template file ${filePath}: ${extractErrorMessage(err)}`, { cause: err });
+              }
+            },
+            { filter: (name) => name.endsWith(".hbs") && name !== "styles" && name !== "lang" },
+          );
         }
 
         // Copy compiled packs (LevelDB output from `npm run pack`)


### PR DESCRIPTION
## Summary

Composite #576 covers three related cleanups in the rolls + chat + mission subsystems:

- **#557** — replace remaining `console.warn` / `console.error` calls with `getDevLogger()` across `init.ts`, `AgentSheet.ts`, and `roll-executor.ts`.
- **#559** — split `foundry/src/rolls/roll-executor.ts` (867 → 453 lines) into `roll-types.ts`, `roll-helpers.ts`, `bank-roll.ts`, `client-roll.ts`, `stress-roll.ts`; extract `buildStressRollDialog` from `AgentSheet.ts` (631 → 579 lines) into `stress-roll-dialog.ts`. All re-exports preserved for backward compatibility.
- **#572** — fix confessional-scene token transition: `TokenDocument.update` does not accept `sceneId` (tokens are scene-embedded). Re-create on target scene via `createEmbeddedDocuments` and delete the source token. Adds GM permission assertion at the public boundary.

## Review-loop fixes

Findings from `npx slop-scan scan . --lint` and pre-pr-review subagents addressed in-branch (per the "no bug left behind" rule codified in this PR):

- `stress-roll.ts`: tightened the `SkillName` runtime guard so the cast happens *after* membership check (no cast-before-check pattern).
- `confessional-scene.ts`: added `assertGm()` boundary check on both public exports; updated test fixtures to stub `game.user.isGM`.
- `franchise/franchise-utils.ts`: JSDoc explaining the typed accessor's purpose (domain-named parallel to `agentSystemData`).
- `vite.config.ts`: preserved original errors via `{ cause: err }` on wrapped throws; removed redundant outer try/catch wrappers around `walkDirectory` calls.
- Codified the "no bug left behind" rule in `.claude/rules/no-bug-left-behind.md` + CLAUDE.md so future workflows don't drop findings as "pre-existing."

## Quality gates

- `npm run lint` — 0 warnings, 0 errors (158 files)
- `npm run check` — 0 type errors
- `npm run test` — 616 passed, 2 skipped, 2 todo
- `npx slop-scan scan . --lint` — clean within touched files

## Test plan

- [ ] Sanity load Foundry with the system installed; confirm agent sheet + franchise sheet open without console errors.
- [ ] Roll skill, bank, client, stress dialogs — verify outcomes render and chat cards appear.
- [ ] Trigger confessional scene transition with at least one token; verify token appears on confessional scene at (400, 400) and source token is deleted.
- [ ] Verify `resetConfessionalScene` returns the token to the original scene.
- [ ] Confirm devMode-gated warnings/errors appear via `getDevLogger` (toggle Developer Mode).

Closes #557
Closes #559
Closes #572
Closes #576