### PR TITLE
fix(#582): franchise sheet dialog UX (z-index, tab focus, X-close)

### DIFF
--- a/foundry/src/franchise/FranchiseSheet.ts
+++ b/foundry/src/franchise/FranchiseSheet.ts
@@ -12,6 +12,10 @@ import { applyEndOfSessionBonuses, initiateBankruptcyRestart } from "./vacation-
 import { stopDialogSubmitPropagation } from "../utils/dialog-utils.js";
 import { updateDocument, createChatMessage } from "../utils/fvtt-boundary.js";
 
+// #552: per-sheet pending focus name, kept in a WeakMap to avoid extending the
+// base class's instance surface (which would break action `this` parameter typing).
+const pendingFocusByInstance = new WeakMap<object, string>();
+
 // HandlebarsApplicationMixin provides _renderHTML/_replaceHTML required by ApplicationV2 for PARTS-based sheets
 export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.sheets.ActorSheetV2) {
   static override readonly DEFAULT_OPTIONS = {
@@ -48,6 +52,28 @@ export class FranchiseSheet extends foundry.applications.api.HandlebarsApplicati
     if (!this.element.dataset["submitGuarded"]) {
       this.element.dataset["submitGuarded"] = "1";
       this.element.addEventListener("submit", (e: Event) => { e.preventDefault(); });
+    }
+    // #552: submitOnChange re-renders on every input change (including when tabbing out),
+    // destroying the upcoming tab target. On blur, FocusEvent.relatedTarget points to the
+    // element about to receive focus — record its name so we can restore focus after the
+    // re-render swaps the DOM.
+    const sheetElement = this.element;
+    for (const input of sheetElement.querySelectorAll<HTMLInputElement>("input[name]")) {
+      input.addEventListener("blur", (event: FocusEvent) => {
+        const next = event.relatedTarget;
+        if (next instanceof HTMLInputElement && sheetElement.contains(next) && next.name) {
+          pendingFocusByInstance.set(this, next.name);
+        }
+      });
+    }
+    const pendingName = pendingFocusByInstance.get(this);
+    if (pendingName) {
+      const restored = sheetElement.querySelector<HTMLInputElement>(`input[name="${pendingName}"]`);
+      if (restored) {
+        restored.focus();
+        restored.select();
+      }
+      pendingFocusByInstance.delete(this);
     }
   }
 

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -397,6 +397,10 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
 
   const result = await foundry.applications.api.DialogV2.wait({
     window: { title: `${i18n?.localize("INSPECTRES.SkillRoll") ?? "Skill Roll"}: ${opts.skillName}` },
+    // #551: modal ensures the dialog renders above the sheet that opened it. Without
+    // modal the skill-roll dialog can appear behind the franchise/agent window when
+    // the originating window holds focus on action click.
+    modal: true,
     rejectClose: false,
     render: stopDialogSubmitPropagation,
     content,

--- a/foundry/src/rolls/stress-roll.ts
+++ b/foundry/src/rolls/stress-roll.ts
@@ -53,14 +53,18 @@ async function getPlayerPenaltyChoice(
   const result = await foundry.applications.api.DialogV2.wait({
     window: { title: game.i18n?.localize("INSPECTRES.PenaltyDialogTitle") ?? "Stress Penalty" },
     classes: ["inspectres"],
+    // #551: modal so the penalty dialog renders above the agent sheet that opened it.
+    modal: true,
     rejectClose: false,
     render: stopDialogSubmitPropagation,
     content,
     buttons: [
       {
+        // #553: No `default: true` — V13 routes X-close through the default button's
+        // callback, which would read the pre-checked first radio and silently apply a
+        // penalty. Without a default, X-close resolves to null and the cancel branch runs.
         action: "select",
         label: game.i18n?.localize("INSPECTRES.DialogOK") ?? "OK",
-        default: true,
         callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
           const form = dialog.element.querySelector("form") as HTMLFormElement | null;
           if (!form) return null;


### PR DESCRIPTION
## Summary

Three UI/UX fixes from sprint composite #582:

- **#553** — Stress penalty dialog X-close no longer applies a penalty. Removed `default: true` on the OK button so V13 routes X-close to a `null` resolution instead of silently invoking the default callback with the pre-checked first radio.
- **#551** — Skill roll dialog (and stress penalty dialog) now render above the sheet that opened them via `modal: true`.
- **#552** — Tab between franchise card inputs preserves focus across `submitOnChange` re-renders. Captures `FocusEvent.relatedTarget` on blur and restores focus on the next `_onRender`. State held in a module-level `WeakMap` keyed by sheet instance to avoid extending the base class's instance surface (which would break action-handler `this` typing).
- **#563** — aria-labels on day +/- buttons (already done pre-branch, included in closing refs).

## Files changed

- `foundry/src/rolls/stress-roll.ts` — drop `default: true`, add `modal: true`
- `foundry/src/rolls/roll-executor.ts` — `modal: true` on skill roll dialog
- `foundry/src/franchise/FranchiseSheet.ts` — focus restore via blur.relatedTarget + module-level WeakMap

## Test plan

- [x] `npm run quality` (lint + tsc + 616 vitest) — clean
- [x] `npx slop-scan scan . --lint` — clean on changed files
- [ ] Manual: open stress penalty dialog, click X — no penalty applied
- [ ] Manual: open skill roll dialog from agent sheet — renders above sheet
- [ ] Manual: tab between library and gym inputs on franchise sheet — focus preserved

Closes #551
Closes #552
Closes #553
Closes #563
Closes #582