### PR TITLE
feat(types): DialogV2 type hygiene + roll test coverage (#595)

### DIFF
--- a/foundry/src/agent/AgentSheet.ts
+++ b/foundry/src/agent/AgentSheet.ts
@@ -470,7 +470,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
           label: i18n?.localize("INSPECTRES.DialogSet") ?? "Set",
           default: true,
           callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-            const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+            const form = dialog.element.querySelector("form");
             if (!form) return null;
             const days = Math.max(1, Math.min(10, Number(new FormData(form).get("days") ?? 2)));
             return { days: Number.isNaN(days) ? 2 : days };
@@ -560,7 +560,7 @@ export class AgentSheet extends foundry.applications.api.HandlebarsApplicationMi
           label: i18n?.localize("INSPECTRES.DialogRestore") ?? "Restore",
           default: true,
           callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-            const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+            const form = dialog.element.querySelector("form");
             if (!form) return null;
             const cool = Math.max(1, Math.min(maxCool, Number(new FormData(form).get("cool") ?? 1)));
             return { cool: Number.isNaN(cool) ? 1 : cool };

--- a/foundry/src/agent/stress-roll-dialog.ts
+++ b/foundry/src/agent/stress-roll-dialog.ts
@@ -28,7 +28,7 @@ export async function buildStressRollDialog(agent: Actor): Promise<void> {
         label: i18n?.localize("INSPECTRES.DialogRoll") ?? "Roll",
         default: true,
         callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+          const form = dialog.element.querySelector("form");
           if (!form) {
             getDevLogger().error("agent-sheet", "buildStressRollDialog: form element not found in dialog");
             return null;

--- a/foundry/src/agent/vacation-dialog.ts
+++ b/foundry/src/agent/vacation-dialog.ts
@@ -88,7 +88,7 @@ export async function buildVacationDialog(options: VacationOptions): Promise<Vac
         label: game.i18n?.localize("INSPECTRES.ButtonSpendBank") ?? "Spend Bank & Recover",
         default: true,
         callback: (_event, _button, dialog) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+          const form = dialog.element.querySelector("form");
           if (!form) return null;
           const data = new FormData(form);
           const bankSpendRaw = Number(data.get("bankSpend") ?? 0);
@@ -116,7 +116,7 @@ export async function buildVacationDialog(options: VacationOptions): Promise<Vac
       {
         action: "skip",
         label: game.i18n?.localize("INSPECTRES.ButtonSkipVacation") ?? "Skip Vacation",
-        callback: (): VacationResult | null => null,
+        callback: () => null,
       },
     ],
   });

--- a/foundry/src/franchise/bankruptcy-handler.ts
+++ b/foundry/src/franchise/bankruptcy-handler.ts
@@ -64,7 +64,7 @@ export async function enterDebtMode(franchiseActor: Actor, attemptedSpend: numbe
         label: game.i18n?.localize("INSPECTRES.ButtonBorrow") ?? "Borrow & Continue",
         default: true,
         callback: (_event, _button, dialog) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+          const form = dialog.element.querySelector("form");
           if (!form) return null;
           const data = new FormData(form);
           const amount = Math.max(0, Math.min(MAX_LOAN_AMOUNT, Number(data.get("borrowAmount") ?? 0)));

--- a/foundry/src/rolls/roll-executor.ts
+++ b/foundry/src/rolls/roll-executor.ts
@@ -412,7 +412,7 @@ async function buildSkillRollDialog(opts: SkillRollDialogOptions): Promise<Skill
         label: i18n?.localize("INSPECTRES.DialogRoll") ?? "Roll",
         default: true,
         callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+          const form = dialog.element.querySelector("form");
           if (!form) {
             getDevLogger().error("roll-executor", "buildSkillRollDialog: form element not found in dialog");
             return null;

--- a/foundry/src/rolls/skill-roll-pipeline.test.ts
+++ b/foundry/src/rolls/skill-roll-pipeline.test.ts
@@ -63,4 +63,44 @@ describe("Skill roll pipeline", () => {
       /good|partial|bad/,
     );
   });
+
+  it("passes a well-formed config to DialogV2.wait", async () => {
+    const agent = makeAgent({ cool: 3 });
+
+    const dialogMock = vi.fn().mockResolvedValue({ diceCount: 2 });
+    const createMessageMock = vi.fn().mockResolvedValue({ id: "msg-1" });
+    const rollConstructor = vi.fn(function (this: unknown) {
+      return { total: 5, evaluate: vi.fn().mockResolvedValue(this) };
+    });
+
+    const g = globalThis as unknown as Record<string, unknown>;
+    g["foundry"] = {
+      applications: { api: { DialogV2: { wait: dialogMock } } },
+    };
+    g["ChatMessage"] = { create: createMessageMock };
+    g["Roll"] = rollConstructor;
+
+    await executeSkillRoll(agent, "cool");
+
+    expect(dialogMock).toHaveBeenCalledTimes(1);
+    const config = dialogMock.mock.calls[0]?.[0] as Record<string, unknown>;
+
+    // Window title includes the skill name passed to executeSkillRoll
+    const windowConfig = config["window"] as Record<string, unknown>;
+    expect(windowConfig["title"]).toBe("Roll cool");
+
+    // Content is a string containing the diceCount input control
+    expect(typeof config["content"]).toBe("string");
+    expect(config["content"] as string).toContain('name="diceCount"');
+
+    // render must be wired up to stop submit propagation (v14 /join bug guard)
+    expect(typeof config["render"]).toBe("function");
+
+    // buttons array with a single "roll" action that returns form data
+    const buttons = config["buttons"] as Array<Record<string, unknown>>;
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.["action"]).toBe("roll");
+    expect(buttons[0]?.["label"]).toBe("Roll");
+    expect(typeof buttons[0]?.["callback"]).toBe("function");
+  });
 });

--- a/foundry/src/rolls/skill-roll-pipeline.ts
+++ b/foundry/src/rolls/skill-roll-pipeline.ts
@@ -1,14 +1,10 @@
 import { stopDialogSubmitPropagation } from "../utils/dialog-utils.js";
+import { createChatMessage } from "../utils/fvtt-boundary.js";
 import type { RollActor } from "./roll-executor.js";
 
 interface DialogResult {
   diceCount?: unknown;
   [key: string]: unknown;
-}
-
-interface Roll {
-  total: number;
-  evaluate(): Promise<Roll>;
 }
 
 type RollOutcome = "good" | "partial" | "bad";
@@ -22,19 +18,16 @@ export async function executeSkillRoll(
   if (!config) return;
 
   const diceCount = Number(config["diceCount"]) || 2;
-  const roll = await evaluateRoll(`${diceCount}d6`);
-  const outcome = determineOutcome(roll.total);
+  const roll = await new Roll(`${diceCount}d6`).evaluate();
+  const total = roll.total ?? 0;
+  const outcome = determineOutcome(total);
 
-  await postRollMessage(actor, skillName, outcome, roll.total);
+  await postRollMessage(actor, skillName, outcome, total);
 }
 
 /** Open a dialog to configure roll parameters (dice count). */
 async function openRollDialog(skillName: string): Promise<DialogResult | null> {
-  const g = globalThis as unknown as Record<string, unknown>;
-  const foundry = g["foundry"] as unknown as {
-    applications: { api: { DialogV2: { wait: Function } } };
-  };
-  const result = (await foundry.applications.api.DialogV2.wait({
+  const result = await foundry.applications.api.DialogV2.wait({
     window: { title: `Roll ${skillName}` },
     content: `<div><input type="number" name="diceCount" value="2"></div>`,
     render: stopDialogSubmitPropagation,
@@ -42,24 +35,15 @@ async function openRollDialog(skillName: string): Promise<DialogResult | null> {
       {
         action: "roll",
         label: "Roll",
-        callback: (_event: Event, _button: unknown, dialog: { element: HTMLElement }) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+        callback: (_event, _button, dialog) => {
+          const form = dialog.element.querySelector("form");
           if (!form) return null;
           return Object.fromEntries(new FormData(form));
         },
       },
     ],
-  })) as unknown;
-  return (result as Record<string, unknown> | null) ?? null;
-}
-
-/** Evaluate a roll formula using Foundry's Roll class. */
-async function evaluateRoll(formula: string): Promise<Roll> {
-  const g = globalThis as unknown as { Roll: new (f: string) => Roll };
-  const roll = new g.Roll(formula);
-  const rollAny = roll as unknown as Record<string, unknown>;
-  const evaluated = await (rollAny["evaluate"] as () => Promise<unknown>)();
-  return evaluated as Roll;
+  });
+  return (result as DialogResult | null) ?? null;
 }
 
 /** Determine outcome (bad/partial/good) based on dice total. */
@@ -76,11 +60,7 @@ async function postRollMessage(
   outcome: RollOutcome,
   total: number,
 ): Promise<void> {
-  const g = globalThis as unknown as Record<string, unknown>;
-  const chatMessage = g["ChatMessage"] as unknown as {
-    create: (data: Record<string, unknown>) => Promise<unknown>;
-  };
-  await chatMessage.create({
+  await createChatMessage({
     content: `Rolled ${total}`,
     speaker: { actor: actor.id },
     flags: {

--- a/foundry/src/rolls/stress-roll.test.ts
+++ b/foundry/src/rolls/stress-roll.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { getStressOutcomeFace, buildStressUpdateData, SKILL_NAMES } from "./stress-roll.js";
+import { STRESS_ROLL_CHART, DEATH_DISMEMBERMENT_CHART } from "./roll-charts.js";
+import type { AgentData } from "../agent/agent-schema.js";
+
+function makeAgentSystem(overrides: Partial<AgentData> = {}): AgentData {
+  return {
+    description: "",
+    skills: {
+      academics: { base: 1, penalty: 0 },
+      athletics: { base: 1, penalty: 0 },
+      technology: { base: 1, penalty: 0 },
+      contact: { base: 1, penalty: 0 },
+    },
+    talent: "",
+    cool: 3,
+    isWeird: false,
+    power: null,
+    characteristics: [],
+    isDead: false,
+    daysOutOfAction: 0,
+    recoveryStartedAt: 0,
+    stress: 0,
+    ...overrides,
+  };
+}
+
+describe("getStressOutcomeFace", () => {
+  it("returns the lowest face when no cool dice are used", () => {
+    expect(getStressOutcomeFace([4, 2, 6], 0)).toBe(2);
+  });
+
+  it("removes the N lowest dice for N cool dice used", () => {
+    // sorted: [1, 3, 5]; removing 1 lowest leaves [3, 5]; lowest of those is 3
+    expect(getStressOutcomeFace([5, 1, 3], 1)).toBe(3);
+  });
+
+  it("removes all dice when cool dice equals dice count, defaulting to face 6", () => {
+    expect(getStressOutcomeFace([1, 2], 2)).toBe(6);
+  });
+
+  it("handles empty dice array as face 6 (no stress applied)", () => {
+    expect(getStressOutcomeFace([], 0)).toBe(6);
+  });
+
+  it("clamps non-DieFace values to 1", () => {
+    // An invalid face like 0 should fall back to the safe lower bound (1)
+    expect(getStressOutcomeFace([0], 0)).toBe(1);
+  });
+
+  it("treats removed-die slot correctly with duplicates", () => {
+    // sorted: [2, 2, 5]; remove 1 leaves [2, 5]; lowest is 2
+    expect(getStressOutcomeFace([2, 5, 2], 1)).toBe(2);
+  });
+});
+
+describe("buildStressUpdateData", () => {
+  it("on meltdown (face 1) zeroes cool and applies meltdown penalty to chosen skill", () => {
+    const system = makeAgentSystem({ cool: 4 });
+    const data = buildStressUpdateData(
+      system,
+      1,
+      STRESS_ROLL_CHART[1],
+      "academics",
+      null,
+      null,
+      3,
+    );
+    expect(data["system.cool"]).toBe(0);
+    expect(data["system.skills.academics.penalty"]).toBe(3);
+  });
+
+  it("on meltdown without meltdown skill choice still zeroes cool", () => {
+    const system = makeAgentSystem({ cool: 2 });
+    const data = buildStressUpdateData(system, 1, STRESS_ROLL_CHART[1], null, null, null, 2);
+    expect(data["system.cool"]).toBe(0);
+    expect("system.skills.academics.penalty" in data).toBe(false);
+  });
+
+  it("on face 6 (TooCool) adds coolGain to current cool, no penalty", () => {
+    const system = makeAgentSystem({ cool: 2 });
+    const data = buildStressUpdateData(system, 6, STRESS_ROLL_CHART[6], null, null, null, 1);
+    expect(data["system.cool"]).toBe(3);
+  });
+
+  it("on face 3 applies the chart's skillPenalty to chosen skill", () => {
+    const system = makeAgentSystem();
+    const data = buildStressUpdateData(
+      system,
+      3,
+      STRESS_ROLL_CHART[3],
+      null,
+      "technology",
+      null,
+      1,
+    );
+    expect(data["system.skills.technology.penalty"]).toBe(STRESS_ROLL_CHART[3].skillPenalty);
+  });
+
+  it("stacks new penalty on top of existing skill penalty", () => {
+    const system = makeAgentSystem({
+      skills: {
+        academics: { base: 1, penalty: 0 },
+        athletics: { base: 1, penalty: 2 },
+        technology: { base: 1, penalty: 0 },
+        contact: { base: 1, penalty: 0 },
+      },
+    });
+    const data = buildStressUpdateData(
+      system,
+      2,
+      STRESS_ROLL_CHART[2],
+      null,
+      "athletics",
+      null,
+      1,
+    );
+    // existing 2 + face-2 chart penalty of 2 = 4
+    expect(data["system.skills.athletics.penalty"]).toBe(4);
+  });
+
+  it("on death outcome with daysOutOfAction sets recovery fields", () => {
+    const system = makeAgentSystem();
+    const data = buildStressUpdateData(
+      system,
+      1,
+      STRESS_ROLL_CHART[1],
+      null,
+      null,
+      DEATH_DISMEMBERMENT_CHART[1],
+      2,
+    );
+    expect(data["system.daysOutOfAction"]).toBe(2);
+    expect(typeof data["system.recoveryStartedAt"]).toBe("number");
+    expect("system.isDead" in data).toBe(false);
+  });
+
+  it("on death outcome with isDead sets isDead but no recovery fields", () => {
+    const system = makeAgentSystem();
+    const data = buildStressUpdateData(
+      system,
+      1,
+      STRESS_ROLL_CHART[1],
+      null,
+      null,
+      DEATH_DISMEMBERMENT_CHART[3],
+      1,
+    );
+    expect(data["system.isDead"]).toBe(true);
+    expect("system.daysOutOfAction" in data).toBe(false);
+  });
+
+  it("does not write cool when coolGain is 0 and not meltdown", () => {
+    const system = makeAgentSystem({ cool: 1 });
+    const data = buildStressUpdateData(system, 4, STRESS_ROLL_CHART[4], null, null, null, 1);
+    expect("system.cool" in data).toBe(false);
+  });
+});
+
+describe("SKILL_NAMES", () => {
+  it("matches the four AgentData skill keys", () => {
+    expect([...SKILL_NAMES].sort()).toEqual(["academics", "athletics", "contact", "technology"]);
+  });
+
+  it("is readonly at the type level", () => {
+    // Sanity: confirm SKILL_NAMES exposes a stable length for dialog rendering
+    expect(SKILL_NAMES.length).toBe(4);
+  });
+});

--- a/foundry/src/rolls/stress-roll.ts
+++ b/foundry/src/rolls/stress-roll.ts
@@ -64,8 +64,8 @@ async function getPlayerPenaltyChoice(
         // penalty. Without a default, X-close resolves to null and the cancel branch runs.
         action: "select",
         label: game.i18n?.localize("INSPECTRES.DialogOK") ?? "OK",
-        callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+        callback: (_event, _button, dialog) => {
+          const form = dialog.element.querySelector("form");
           if (!form) return null;
           const data = new FormData(form);
           const selectedSkill = data.get("selectedSkill");
@@ -87,7 +87,7 @@ async function getPlayerPenaltyChoice(
 }
 
 /** Compute effective face after cool dice removed. */
-function getStressOutcomeFace(faces: number[], coolDiceUsed: number): DieFace {
+export function getStressOutcomeFace(faces: number[], coolDiceUsed: number): DieFace {
   const sorted = [...faces].sort((a, b) => a - b);
   const active = sorted.slice(coolDiceUsed);
   const rawLowest = active.length > 0 ? (active[0] ?? 6) : 6;
@@ -139,7 +139,7 @@ async function getPenaltyChoices(
 }
 
 /** Build update data from stress roll outcome and choices. */
-function buildStressUpdateData(
+export function buildStressUpdateData(
   system: AgentData,
   effectiveFace: DieFace,
   outcome: StressRollOutcome,

--- a/foundry/src/types/foundry-v2.d.ts
+++ b/foundry/src/types/foundry-v2.d.ts
@@ -78,43 +78,43 @@ declare namespace foundry.applications.api {
     callback?: (event: Event, button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => unknown;
   }
 
+  /**
+   * Shared config shape for DialogV2.wait() and DialogV2.prompt().
+   *
+   * Extracted as a named interface (not inlined) so the LSP and tsc agree on
+   * the type identity of the parameter — inlined object types caused LSP to
+   * synthesize a different structural type than tsc resolved (#577).
+   */
+  interface DialogV2WaitConfig {
+    content: string;
+    window?: { title?: string };
+    position?: ApplicationV2Options["position"];
+    classes?: string[];
+    rejectClose?: boolean;
+    modal?: boolean;
+    buttons?: DialogV2Button[];
+    /** Called each time the dialog renders. Use to attach extra listeners. */
+    render?: ((event: Event, dialog: foundry.applications.api.DialogV2) => void) | null;
+    /** Called when the dialog closes under any circumstances. */
+    close?: ((event: Event, dialog: foundry.applications.api.DialogV2) => unknown) | null;
+  }
+
+  /** Confirm uses a narrower shape (no buttons array; no position). */
+  interface DialogV2ConfirmConfig {
+    content: string;
+    window?: { title?: string };
+    classes?: string[];
+    rejectClose?: boolean;
+    modal?: boolean;
+    render?: ((event: Event, dialog: foundry.applications.api.DialogV2) => void) | null;
+    close?: ((event: Event, dialog: foundry.applications.api.DialogV2) => unknown) | null;
+  }
+
   /** Modal/modeless dialog built on ApplicationV2. */
   class DialogV2 extends ApplicationV2 {
-    static wait(config: {
-      content: string;
-      window?: { title?: string };
-      position?: ApplicationV2Options["position"];
-      classes?: string[];
-      rejectClose?: boolean;
-      modal?: boolean;
-      buttons?: DialogV2Button[];
-      /** Called each time the dialog renders. Use to attach extra listeners. */
-      render?: ((event: Event, dialog: foundry.applications.api.DialogV2) => void) | null;
-      /** Called when the dialog closes under any circumstances. */
-      close?: ((event: Event, dialog: foundry.applications.api.DialogV2) => unknown) | null;
-    }): Promise<unknown>;
-
-    static prompt(config: {
-      content: string;
-      window?: { title?: string };
-      position?: ApplicationV2Options["position"];
-      classes?: string[];
-      rejectClose?: boolean;
-      modal?: boolean;
-      buttons?: DialogV2Button[];
-      render?: ((event: Event, dialog: foundry.applications.api.DialogV2) => void) | null;
-      close?: ((event: Event, dialog: foundry.applications.api.DialogV2) => unknown) | null;
-    }): Promise<unknown>;
-
-    static confirm(config: {
-      content: string;
-      window?: { title?: string };
-      classes?: string[];
-      rejectClose?: boolean;
-      modal?: boolean;
-      render?: ((event: Event, dialog: foundry.applications.api.DialogV2) => void) | null;
-      close?: ((event: Event, dialog: foundry.applications.api.DialogV2) => unknown) | null;
-    }): Promise<boolean>;
+    static wait(config: DialogV2WaitConfig): Promise<unknown>;
+    static prompt(config: DialogV2WaitConfig): Promise<unknown>;
+    static confirm(config: DialogV2ConfirmConfig): Promise<boolean>;
   }
 
   /**

--- a/foundry/src/utils/distribution-dialog.ts
+++ b/foundry/src/utils/distribution-dialog.ts
@@ -60,7 +60,7 @@ export async function buildDistributionConfig(opts: DistributionDialogOptions): 
         label: game.i18n?.localize("INSPECTRES.DistributeDialogConfirm") ?? "Confirm",
         default: true,
         callback: (_event: Event, _button: HTMLButtonElement, dialog: foundry.applications.api.DialogV2) => {
-          const form = dialog.element.querySelector("form") as HTMLFormElement | null;
+          const form = dialog.element.querySelector("form");
           if (!form) return null;
           const data = new FormData(form);
           const distribution: Record<string, number> = {};


### PR DESCRIPTION
## Summary

Sprint #595 — type-system hygiene around DialogV2 plus targeted test coverage for the rolls module.

- **#577** — Extract `DialogV2WaitConfig` / `DialogV2ConfirmConfig` as named interfaces in `foundry-v2.d.ts`. Inlined object types caused LSP and `tsc` to disagree on type identity for `classes`. Named interfaces give both tools the same structural anchor.
- **#591** — Drop `globalThis as unknown as Record<string, unknown>` casts from `skill-roll-pipeline.ts`. Use ambient `DialogV2`, global `Roll`, and the existing `createChatMessage` helper.
- **#590** — Standardize DialogV2 callback annotations across `stress-roll.ts`, `vacation-dialog.ts`, and `bankruptcy-handler.ts`. Drop redundant `as HTMLFormElement | null` casts — `querySelector("form")` already returns the right type. Same fix applied to variant sites flagged by variant-bug-hunter (AgentSheet.ts, stress-roll-dialog.ts, roll-executor.ts, distribution-dialog.ts) per the no-bug-left-behind rule.
- **#592** — Extend `skill-roll-pipeline.test.ts` with an assertion on the DialogV2 config shape (window title, content, render function, buttons array).
- **#593** — New `stress-roll.test.ts` with 16 focused unit tests across `getStressOutcomeFace`, `buildStressUpdateData`, and `SKILL_NAMES`.

## Deferred work

#596 — Migrate fully to fvtt-types upstream when v13 coverage lands; remove `foundry-v2.d.ts` ambient declarations.

## Test plan

- [x] `npm run quality` clean (lint + tsc + 71 test files, 635 tests passing)
- [x] `npx slop-scan scan . --lint` — no findings in changed files

Closes #577
Closes #590
Closes #591
Closes #592
Closes #593
Closes #595