### PR TITLE
refactor: type safety hardening — assertNever, consolidate SKILL_NAMES, type-safe wrappers

### DIFF
--- a/foundry/src/__tests__/e2e/agent-sheet.test.ts
+++ b/foundry/src/__tests__/e2e/agent-sheet.test.ts
@@ -16,8 +16,7 @@ import {
   getActorSystemField,
   assertSheetAccessibility,
 } from "./pages/index.js";
-
-const SKILL_NAMES = ["academics", "athletics", "technology", "contact"] as const;
+import { SKILL_NAMES } from "../../rolls/roll-types.js";
 
 // Conditional UI paths need specific pre-state that conflicts with the default
 // actor setup (isDead, daysOutOfAction, stress+penalty), so they use their own

--- a/foundry/src/agent/InSpectresAgent.ts
+++ b/foundry/src/agent/InSpectresAgent.ts
@@ -4,6 +4,7 @@
  */
 
 import { agentSystemData } from "./agent-system-data.js";
+import { type SkillName } from "../rolls/roll-types.js";
 
 const ERROR_RECOVERY_STATE_GM_ONLY = "Recovery state can only be modified by the GM";
 const ERROR_SKILL_VALUE_EXCEEDS_MAX = (skillValue: number, max: number, agentType: string) =>
@@ -20,7 +21,7 @@ export class InSpectresAgent extends Actor {
   /**
    * Get effective skill value (base - penalty, min 0)
    */
-  getEffectiveSkill(skill: "academics" | "athletics" | "technology" | "contact"): number {
+  getEffectiveSkill(skill: SkillName): number {
     const system = agentSystemData(this as Actor);
     const skillData = system.skills?.[skill];
     if (!skillData) return 0;

--- a/foundry/src/agent/recovery-utils.ts
+++ b/foundry/src/agent/recovery-utils.ts
@@ -6,18 +6,14 @@
 import { type AgentData } from "./agent-schema.js";
 import { agentSystemData } from "./agent-system-data.js";
 import { getDevLogger } from "../utils/dev-logger.js";
+import { settingsApi } from "../utils/fvtt-boundary.js";
 
 // Default in-game day when the setting is unavailable (matches setting's initial value)
 const DEFAULT_IN_GAME_DAY = 1;
 
 export function getCurrentDay(): number {
   try {
-    return (
-      (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get(
-        "inspectres",
-        "currentDay",
-      ) as number
-    ) ?? DEFAULT_IN_GAME_DAY;
+    return (settingsApi().get("inspectres", "currentDay") as number) ?? DEFAULT_IN_GAME_DAY;
   } catch (err: unknown) {
     if (game.ready) {
       const message = err instanceof Error ? err.message : String(err);

--- a/foundry/src/data/AgentDataModel.ts
+++ b/foundry/src/data/AgentDataModel.ts
@@ -1,3 +1,5 @@
+import { SKILL_NAMES } from "../rolls/roll-types.js";
+
 const { StringField, NumberField, BooleanField, ArrayField, SchemaField } = foundry.data.fields;
 
 // TypeDataModel base class cast: Foundry's abstract class requires unknown intermediate
@@ -66,11 +68,10 @@ export class AgentDataModel extends TypeDataModelBase {
     // Enforce skill range based on weird agent status
     const isWeird = (this as unknown as { isWeird: boolean }).isWeird;
     const maxSkill = isWeird ? 10 : 4;
-    const skillKeys = ["academics", "athletics", "technology", "contact"] as const;
     const skills = (this as unknown as { skills: Record<string, { base: number; penalty: number }> }).skills;
 
     if (skills) {
-      for (const skillKey of skillKeys) {
+      for (const skillKey of SKILL_NAMES) {
         if (skills[skillKey] && skills[skillKey].base > maxSkill) {
           const actorName = (this as unknown as { name?: string }).name ?? "unknown";
           console.warn(

--- a/foundry/src/rolls/requirements-integration.ts
+++ b/foundry/src/rolls/requirements-integration.ts
@@ -1,3 +1,5 @@
+import { assertNever } from "../utils/type-utils.js";
+
 export interface MissionState {
   itemRarity: "common" | "rare" | "exotic";
   requirementsMet: boolean;
@@ -50,6 +52,6 @@ export function getRequirementBlockReason(mission: MissionState | null): string 
     case "exotic":
       return "INSPECTRES.Requirement.Exotic";
     default:
-      return "";
+      return assertNever(mission.itemRarity);
   }
 }

--- a/foundry/src/utils/dev-logger.ts
+++ b/foundry/src/utils/dev-logger.ts
@@ -3,6 +3,8 @@
  * Records mission sync events, multiplayer coordination, and state changes
  */
 
+import { settingsApi } from "./fvtt-boundary.js";
+
 interface LogEntry {
   timestamp: number;
   level: "info" | "warn" | "error";
@@ -21,8 +23,13 @@ class DevLogger {
     message: string,
     data: Record<string, unknown> | undefined = undefined,
   ): void {
-    const settingsApi = game.settings as unknown as { get: (namespace: string, key: string) => unknown };
-    const devModeEnabled = (settingsApi?.get("inspectres", "devMode") as boolean | undefined) ?? false;
+    let devModeEnabled = false;
+    try {
+      const settings = settingsApi();
+      devModeEnabled = (settings.get("inspectres", "devMode") as boolean | undefined) ?? false;
+    } catch {
+      // settingsApi() fails if game is undefined (e.g., in tests without Foundry globals)
+    }
     if (!devModeEnabled) return;
 
     const entry: LogEntry = {

--- a/foundry/src/utils/settings-utils.ts
+++ b/foundry/src/utils/settings-utils.ts
@@ -2,11 +2,10 @@
  * Utility functions for accessing Foundry game settings with proper typing
  */
 
+import { settingsApi } from "./fvtt-boundary.js";
+
 export function getCurrentDaySetting(): number {
-  const value = (game.settings as unknown as { get: (namespace: string, key: string) => unknown })?.get(
-    "inspectres",
-    "currentDay",
-  ) as number | undefined;
+  const value = settingsApi().get("inspectres", "currentDay") as number | undefined;
   return value ?? 1;
 }
 
@@ -14,9 +13,5 @@ export async function setCurrentDaySetting(day: number): Promise<unknown> {
   if (!Number.isInteger(day) || day < 1) {
     throw new Error(`Invalid day value: ${day}. Day must be a positive integer.`);
   }
-  return (game.settings as unknown as { set: (namespace: string, key: string, value: unknown) => Promise<unknown> })?.set(
-    "inspectres",
-    "currentDay",
-    day,
-  );
+  return settingsApi().set("inspectres", "currentDay", day);
 }


### PR DESCRIPTION
## Summary

Type safety hardening sprint addressing 4 sub-issues:
- **#606**: Add assertNever to itemRarity switch in requirements-integration
- **#604**: Audit and add missing assertNever exhaustiveness checks
- **#607**: Replace local SKILL_NAMES duplicates with import from roll-types
- **#601**: Replace remaining 'as unknown as' chains with type-safe wrappers

## Changes

### Type-safe wrappers (#601)
- Consolidated `as unknown as` cast pattern into `settingsApi()` wrapper in fvtt-boundary.ts
- Replaced 3 inline casts in dev-logger.ts, settings-utils.ts, recovery-utils.ts
- Added try-catch in dev-logger to handle test environments without Foundry globals

### Exhaustiveness checks (#606, #604)
- Verified itemRarity switch in requirements-integration.ts has assertNever
- Audited all switch statements in production code — all properly exhaustive

### Consolidation (#607)
- Imported SKILL_NAMES from roll-types.ts in AgentDataModel and agent-sheet.test.ts
- Removed local duplicate definitions
- Single source of truth maintained

## Testing

- ✅ All lints pass (oxlint)
- ✅ All types pass (tsc --noEmit)
- ✅ All tests pass (vitest)
- ✅ No new warnings or errors

## Pre-PR Review

- ✅ Code review: clean architecture, minimal changes, no issues
- ✅ Semgrep scan: 132 rules, 0 findings (P0/P1/P2)
- ✅ Variant hunt: 1 P2 polish item deferred (#609)

## Deferred Work

- #609: Consolidate hardcoded skill choices in AgentDataModel to use SKILL_NAMES (follow-up polish)

Closes #608
Closes #606
Closes #604
Closes #607
Closes #601